### PR TITLE
feat(booking): return machine-readable conflict and blackout errors

### DIFF
--- a/portal/application/facility/booking_service.py
+++ b/portal/application/facility/booking_service.py
@@ -1,10 +1,11 @@
 """
 Facility booking admin application service.
 """
-from datetime import datetime, timezone
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
 
 from portal.application.facility.commands import (
     BookingPagesQueryCommand,
@@ -19,12 +20,18 @@ from portal.application.facility.results import BookingDetailResult, BookingList
 from portal.application.org.results import CreateIdResult
 from portal.application.system.setting_service import SettingService
 from portal.domain.facility.constants import (
+    BookingErrorCode,
     BookingSlotStatus,
     BookingStatus,
     BookingType,
     RentalPolicySettingKey,
 )
-from portal.exceptions.responses import BadRequestException, ForbiddenException, NotFoundException
+from portal.exceptions.responses import (
+    BadRequestException,
+    ConflictErrorException,
+    ForbiddenException,
+    NotFoundException,
+)
 from portal.infrastructure.persistence.repositories.facility.booking_repository import BookingRepository
 from portal.infrastructure.persistence.repositories.facility.rental_repository import RentalRepository
 from portal.infrastructure.persistence.repositories.facility.room_blackout_repository import (
@@ -119,20 +126,13 @@ class BookingService:
         for line in command.rooms:
             start_at = line.start_at or command.start_at
             end_at = line.end_at or command.end_at
-            if await self._repository.has_confirmed_slot_overlap(
+            await self._raise_if_room_unavailable(
                 facility_id=line.facility_id,
                 start_at=start_at,
                 end_at=end_at,
+                local_tz=local_tz,
                 exclude_booking_id=booking_id,
-            ):
-                raise BadRequestException(detail=f"Room {line.facility_id} has a scheduling conflict")
-            if await self._blackout_repository.has_blackout_overlap(
-                facility_id=line.facility_id,
-                start_at=start_at,
-                end_at=end_at,
-                tz=local_tz,
-            ):
-                raise BadRequestException(detail=f"Room {line.facility_id} is closed for the selected time")
+            )
 
         quote_lines = []
         for line in command.rooms:
@@ -242,19 +242,12 @@ class BookingService:
         for line in command.rooms:
             start_at = line.start_at or command.start_at
             end_at = line.end_at or command.end_at
-            if await self._repository.has_confirmed_slot_overlap(
+            await self._raise_if_room_unavailable(
                 facility_id=line.facility_id,
                 start_at=start_at,
                 end_at=end_at,
-            ):
-                raise BadRequestException(detail=f"Room {line.facility_id} has a scheduling conflict")
-            if await self._blackout_repository.has_blackout_overlap(
-                facility_id=line.facility_id,
-                start_at=start_at,
-                end_at=end_at,
-                tz=local_tz,
-            ):
-                raise BadRequestException(detail=f"Room {line.facility_id} is closed for the selected time")
+                local_tz=local_tz,
+            )
 
         quote_lines = []
         for line in command.rooms:
@@ -358,6 +351,37 @@ class BookingService:
         if owner_id != user_id:
             raise ForbiddenException(detail="Cannot cancel another user's booking")
         await self.cancel_booking(booking_id, command)
+
+    async def _raise_if_room_unavailable(
+        self,
+        facility_id: UUID,
+        start_at: datetime,
+        end_at: datetime,
+        local_tz: ZoneInfo,
+        exclude_booking_id: Optional[UUID] = None,
+    ) -> None:
+        if await self._repository.has_confirmed_slot_overlap(
+            facility_id=facility_id,
+            start_at=start_at,
+            end_at=end_at,
+            exclude_booking_id=exclude_booking_id,
+        ):
+            raise ConflictErrorException(
+                detail=f"Room {facility_id} has a scheduling conflict",
+                error_code=BookingErrorCode.SCHEDULING_CONFLICT.value,
+                context={"facility_id": str(facility_id)},
+            )
+        if await self._blackout_repository.has_blackout_overlap(
+            facility_id=facility_id,
+            start_at=start_at,
+            end_at=end_at,
+            tz=local_tz,
+        ):
+            raise BadRequestException(
+                detail=f"Room {facility_id} is closed for the selected time",
+                error_code=BookingErrorCode.ROOM_BLACKOUT.value,
+                context={"facility_id": str(facility_id)},
+            )
 
     async def _validate_ministry_booking_gate(
         self,

--- a/portal/apps.py
+++ b/portal/apps.py
@@ -99,6 +99,10 @@ def _setup_exception_handlers(application: FastAPI) -> None:
             await session.rollback()
         content = defaultdict()
         content["detail"] = exc.detail
+        if exc.error_code:
+            content["error_code"] = exc.error_code
+        if exc.context:
+            content["context"] = exc.context
         if settings.is_dev:
             content["debug_detail"] = exc.debug_detail
             content["url"] = str(request.url)

--- a/portal/domain/facility/constants.py
+++ b/portal/domain/facility/constants.py
@@ -88,3 +88,10 @@ class RoomBlackoutKind(str, Enum):
 
     ONE_OFF = "one_off"
     RECURRING = "recurring"
+
+
+class BookingErrorCode(str, Enum):
+    """Machine-readable booking create/update error codes for clients."""
+
+    SCHEDULING_CONFLICT = "FACILITY_BOOKING_SCHEDULING_CONFLICT"
+    ROOM_BLACKOUT = "FACILITY_BOOKING_ROOM_BLACKOUT"

--- a/portal/exceptions/responses/base.py
+++ b/portal/exceptions/responses/base.py
@@ -22,7 +22,9 @@ class ApiBaseException(HTTPException):
             detail=detail,
             headers=headers
         )
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        self.debug_detail = kwargs.pop("debug_detail", None)
+        self.error_code = kwargs.pop("error_code", None)
+        self.context = kwargs.pop("context", None)
 
     def __str__(self):
         return self.detail or ""
@@ -37,8 +39,12 @@ class BadRequestException(ApiBaseException):
         headers: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
-        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail, headers=headers)
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail,
+            headers=headers,
+            **kwargs,
+        )
 
 
 class ParamError(BadRequestException):
@@ -57,8 +63,12 @@ class NotFoundException(ApiBaseException):
         headers: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
-        super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail, headers=headers)
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=detail,
+            headers=headers,
+            **kwargs,
+        )
 
 
 class ConflictErrorException(ApiBaseException):
@@ -73,8 +83,12 @@ class ConflictErrorException(ApiBaseException):
         headers: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
-        super().__init__(status_code=status.HTTP_409_CONFLICT, detail=detail, headers=headers)
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        super().__init__(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=detail,
+            headers=headers,
+            **kwargs,
+        )
 
 
 class EntityTooLargeException(ApiBaseException):
@@ -89,8 +103,12 @@ class EntityTooLargeException(ApiBaseException):
         headers: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
-        super().__init__(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=detail, headers=headers)
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        super().__init__(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=detail,
+            headers=headers,
+            **kwargs,
+        )
 
 
 class NotImplementedException(ApiBaseException):
@@ -105,5 +123,9 @@ class NotImplementedException(ApiBaseException):
         headers: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
-        super().__init__(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=detail, headers=headers)
-        self.debug_detail = kwargs.pop('debug_detail', None)
+        super().__init__(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=detail,
+            headers=headers,
+            **kwargs,
+        )

--- a/tests/application/facility/test_booking_service.py
+++ b/tests/application/facility/test_booking_service.py
@@ -11,7 +11,12 @@ from portal.application.facility.booking_service import BookingService
 from portal.application.facility.commands import BookingRoomLineCommand, CancelBookingCommand
 from portal.application.facility.results import BookingDetailResult
 from portal.domain.facility.constants import RentalPolicySettingKey
-from portal.exceptions.responses import BadRequestException, ForbiddenException, NotFoundException
+from portal.exceptions.responses import (
+    BadRequestException,
+    ConflictErrorException,
+    ForbiddenException,
+    NotFoundException,
+)
 from tests.fixtures.facility.factories import (
     make_create_booking_command,
     make_ministry_detail,
@@ -96,8 +101,10 @@ async def test_update_booking_invalid_time_range():
         end_at=datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc),
     )
     service = _booking_service(StubBookingRepository())
-    with pytest.raises(BadRequestException, match="end_at"):
+    with pytest.raises(BadRequestException) as exc_info:
         await service.update_booking(uuid4(), command)
+    assert "end_at" in str(exc_info.value.detail)
+    assert getattr(exc_info.value, "error_code", None) is None
 
 
 @pytest.mark.asyncio
@@ -121,8 +128,10 @@ async def test_update_booking_max_rooms_exceeded():
         for idx, room_id in enumerate(room_ids)
     ]
     service = _booking_service(StubBookingRepository(), rental)
-    with pytest.raises(BadRequestException, match="At most 2"):
+    with pytest.raises(BadRequestException) as exc_info:
         await service.update_booking(uuid4(), command)
+    assert "At most 2" in str(exc_info.value.detail)
+    assert getattr(exc_info.value, "error_code", None) is None
 
 
 @pytest.mark.asyncio
@@ -130,8 +139,13 @@ async def test_update_booking_slot_overlap_conflict():
     room_id = new_uuid()
     stub = StubBookingRepository(has_overlap=True)
     service = _booking_service(stub)
-    with pytest.raises(BadRequestException, match="scheduling conflict"):
+    with pytest.raises(ConflictErrorException) as exc_info:
         await service.update_booking(uuid4(), make_update_booking_command(facility_id=room_id))
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.error_code == "FACILITY_BOOKING_SCHEDULING_CONFLICT"
+    assert exc.context == {"facility_id": str(room_id)}
+    assert "scheduling conflict" in str(exc.detail)
 
 
 @pytest.mark.asyncio
@@ -139,8 +153,13 @@ async def test_update_booking_blackout_conflict():
     room_id = new_uuid()
     stub = StubBookingRepository(has_overlap=False)
     service = _booking_service(stub, blackout_stub=StubRoomBlackoutRepository(has_overlap=True))
-    with pytest.raises(BadRequestException, match="closed for the selected time"):
+    with pytest.raises(BadRequestException) as exc_info:
         await service.update_booking(uuid4(), make_update_booking_command(facility_id=room_id))
+    exc = exc_info.value
+    assert exc.status_code == 400
+    assert exc.error_code == "FACILITY_BOOKING_ROOM_BLACKOUT"
+    assert exc.context == {"facility_id": str(room_id)}
+    assert "closed for the selected time" in str(exc.detail)
 
 
 @pytest.mark.asyncio
@@ -249,20 +268,32 @@ async def test_create_booking_rejects_when_booker_not_ministry_member(monkeypatc
 @pytest.mark.asyncio
 async def test_create_booking_slot_overlap_conflict(monkeypatch):
     _user_ctx(monkeypatch)
+    room_id = new_uuid()
     service = _booking_service(StubBookingRepository(has_overlap=True))
-    with pytest.raises(BadRequestException, match="scheduling conflict"):
-        await service.create_booking(make_create_booking_command())
+    with pytest.raises(ConflictErrorException) as exc_info:
+        await service.create_booking(make_create_booking_command(facility_id=room_id))
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.error_code == "FACILITY_BOOKING_SCHEDULING_CONFLICT"
+    assert exc.context == {"facility_id": str(room_id)}
+    assert "scheduling conflict" in str(exc.detail)
 
 
 @pytest.mark.asyncio
 async def test_create_booking_blackout_conflict(monkeypatch):
     _user_ctx(monkeypatch)
+    room_id = new_uuid()
     service = _booking_service(
         StubBookingRepository(has_overlap=False),
         blackout_stub=StubRoomBlackoutRepository(has_overlap=True),
     )
-    with pytest.raises(BadRequestException, match="closed for the selected time"):
-        await service.create_booking(make_create_booking_command())
+    with pytest.raises(BadRequestException) as exc_info:
+        await service.create_booking(make_create_booking_command(facility_id=room_id))
+    exc = exc_info.value
+    assert exc.status_code == 400
+    assert exc.error_code == "FACILITY_BOOKING_ROOM_BLACKOUT"
+    assert exc.context == {"facility_id": str(room_id)}
+    assert "closed for the selected time" in str(exc.detail)
 
 
 @pytest.mark.asyncio
@@ -278,5 +309,43 @@ async def test_create_booking_max_rooms_exceeded(monkeypatch):
         for idx, room_id in enumerate(room_ids)
     ]
     service = _booking_service(StubBookingRepository(), rental)
-    with pytest.raises(BadRequestException, match="At most 2"):
+    with pytest.raises(BadRequestException) as exc_info:
         await service.create_booking(command)
+    assert "At most 2" in str(exc_info.value.detail)
+    assert getattr(exc_info.value, "error_code", None) is None
+
+
+@pytest.mark.asyncio
+async def test_create_booking_invalid_time_range_has_no_error_code(monkeypatch):
+    _user_ctx(monkeypatch)
+    command = make_create_booking_command(
+        start_at=datetime(2026, 5, 1, 14, 0, tzinfo=timezone.utc),
+        end_at=datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc),
+    )
+    service = _booking_service(StubBookingRepository())
+    with pytest.raises(BadRequestException) as exc_info:
+        await service.create_booking(command)
+    assert "end_at" in str(exc_info.value.detail)
+    assert getattr(exc_info.value, "error_code", None) is None
+
+
+@pytest.mark.asyncio
+async def test_create_booking_scheduling_conflict_is_first_fail(monkeypatch):
+    _user_ctx(monkeypatch)
+    first_room_id = new_uuid()
+    second_room_id = new_uuid()
+
+    class FirstRoomOverlapRepository(StubBookingRepository):
+        async def has_confirmed_slot_overlap(self, facility_id, start_at, end_at, exclude_booking_id=None):
+            return facility_id == first_room_id
+
+    command = make_create_booking_command(facility_id=first_room_id)
+    command.rooms = [
+        BookingRoomLineCommand(facility_id=first_room_id, sequence=0),
+        BookingRoomLineCommand(facility_id=second_room_id, sequence=1),
+    ]
+    service = _booking_service(FirstRoomOverlapRepository())
+    with pytest.raises(ConflictErrorException) as exc_info:
+        await service.create_booking(command)
+    assert exc_info.value.context == {"facility_id": str(first_room_id)}
+    assert exc_info.value.error_code == "FACILITY_BOOKING_SCHEDULING_CONFLICT"


### PR DESCRIPTION
## Summary

Admin booking create/update now returns a stable `error_code` and `context.facility_id` for Scheduling Conflict and Blackout, so the portal can map i18n prompts without parsing English `detail`.

Closes #54

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Scheduling Conflict: HTTP **409** + `FACILITY_BOOKING_SCHEDULING_CONFLICT` + `{ "facility_id": "<uuid>" }`
- Blackout: HTTP **400** + `FACILITY_BOOKING_ROOM_BLACKOUT` + `{ "facility_id": "<uuid>" }`
- First-fail: only the first failing room is returned
- `ApiBaseException` optionally carries `error_code` / `context`; the handler emits those keys only when set
- Invalid time range and max-rooms still return ordinary 400 **without** `error_code`
- Existing uniqueness `ConflictErrorException` responses are unchanged
- Contract: `docs/adr/0001-booking-business-error-codes.md`

## Testing

- [x] `poetry run pytest tests/application/facility/test_booking_service.py`
- [x] `poetry run pytest`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge