### PR TITLE
feat: add seed-ministries CLI for ten demo Active ministries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,13 @@ _Avoid_: generic "conflict", treating Blackout as the same failure, parsing the 
 **Blackout**:
 A room-closed interval that makes the room unbookable. Overlap with a Blackout is a distinct rejection from a Scheduling Conflict; the client must show a different prompt.
 _Avoid_: scheduling conflict, "closed" without naming the Blackout rule
+
+### Org / ministry
+
+**Annual Ministry**:
+A ministry that runs as one distinct edition per year, with the year in its name (e.g. Alpha 2026). Next year's edition is a **new** Ministry record, not the same row with shifted dates, so each year keeps its own approval, stewards, and history.
+_Avoid_: recycling last year's row by editing its dates, treating the year as a Seasonal schedule bound
+
+**Seasonal schedule**:
+An ongoing weekly Ministry whose pattern only applies inside a date window, expressed as `effective_from` / `effective_to` on its schedule rows (e.g. a Saturday class that pauses June through August). The Ministry stays a single record across seasons.
+_Avoid_: one Ministry per season, calling a bounded weekly pattern an Annual Ministry

--- a/README.md
+++ b/README.md
@@ -472,7 +472,10 @@ uv run python -m portal.cli.main seed-positions
 uv run python -m portal.cli.main seed-ministry-types
 uv run python -m portal.cli.main seed-target-audiences
 
-# 6. Optional: facility rooms/rates, then demo slot templates + blackouts
+# 6. Optional: demo Active ministries (needs steps 1, 4, and 5)
+uv run python -m portal.cli.main seed-ministries
+
+# 7. Optional: facility rooms/rates, then demo slot templates + blackouts
 uv run python -m portal.cli.main seed-facility-rental
 uv run python -m portal.cli.main seed-facility-slots
 ```
@@ -485,6 +488,7 @@ uv run python -m portal.cli.main seed-facility-slots
 | `seed-positions`        | Upsert org positions and translations from `portal/cli/datas/position_seed_data.py`.                                          |
 | `seed-ministry-types`   | Upsert ministry type catalog (`outreach`, `internal`, `worship`) and translations.                                            |
 | `seed-target-audiences` | Upsert target audience catalog (`children`, `youths`, `adults`, `family`, `all_ages`) and translations.                       |
+| `seed-ministries`       | Replace demo (`seed: Demo `-prefixed) ministries with ten Active ministries plus a simulated approval.                        |
 | `seed-facility-rental`  | Upsert facility rooms, rates, discounts, surcharges, and policy settings.                                                     |
 | `seed-facility-slots`   | Replace demo (`seed:`-prefixed) room slot templates and blackouts for existing rooms.                                         |
 | `reset-rbac`            | **Destructive:** delete all RBAC data and re-seed from `rbac_seed_data`.                                                      |
@@ -492,8 +496,9 @@ uv run python -m portal.cli.main seed-facility-slots
 Notes:
 
 - Run `init-locales` before `init-rbac`; RBAC translations depend on locale rows.
-- `seed-positions`, `seed-ministry-types`, `seed-target-audiences`, `seed-facility-rental`, `seed-facility-slots`, and `reset-rbac` are blocked when `ENV` is not `dev` unless `--force` is passed.
+- `seed-positions`, `seed-ministry-types`, `seed-target-audiences`, `seed-ministries`, `seed-facility-rental`, `seed-facility-slots`, and `reset-rbac` are blocked when `ENV` is not `dev` unless `--force` is passed.
 - Run `seed-facility-rental` before `seed-facility-slots` so room codes exist.
+- Run `init-locales`, `seed-ministry-types`, `seed-target-audiences`, and `seed-positions` before `seed-ministries`; it fails fast and names the missing prerequisite. It also creates two non-admin demo stewards (`seed.ministry.primary@local.test`, `seed.ministry.secondary@local.test`) if they do not exist, and never deletes them on re-run.
 - Seed logic lives in `portal/application/cli/*_seed_service.py`; `portal/cli/` provides thin Click entrypoints only.
 
 ## Run FastAPI server

--- a/portal/application/cli/ministry_seed_service.py
+++ b/portal/application/cli/ministry_seed_service.py
@@ -120,25 +120,32 @@ async def _load_owning_position_ids(session: Session) -> list[UUID]:
 async def _ensure_demo_user(session: Session, row: dict[str, Any]) -> UUID:
     """Return the demo steward user id, creating a non-admin account when missing."""
     email = (row["email"] or "").strip().lower()
+    first_name = row["first_name"]
+    last_name = row["last_name"]
+    # Ministry member lists display preferred_name and fall back to the email.
+    preferred_name = f"{first_name} {last_name}"
+
     existing_id = await session.select(AuthUser.id).where(AuthUser.email == email).fetchval()
     if existing_id:
         # The email is unique, so a soft-deleted or deactivated demo user cannot be
         # re-created. Restore the flags the seeded ministries rely on instead.
-        await session.update(AuthUser).values(is_active=True, verified=True, is_deleted=False).where(AuthUser.id == existing_id).execute()
-        return _as_uuid(existing_id)
+        user_id = _as_uuid(existing_id)
+        await session.update(AuthUser).values(is_active=True, verified=True, is_deleted=False).where(AuthUser.id == user_id).execute()
+    else:
+        user_id = uuid.uuid4()
+        await (
+            session.insert(AuthUser)
+            .values(id=user_id, email=email, password_hash=None, verified=True, is_active=True, is_superuser=False, is_admin=False)
+            .execute()
+        )
+        click.echo(f"Created demo ministry user: {email}")
 
-    user_id = uuid.uuid4()
-    await (
-        session.insert(AuthUser)
-        .values(id=user_id, email=email, password_hash=None, verified=True, is_active=True, is_superuser=False, is_admin=False)
-        .execute()
-    )
     await (
         session.insert(AuthUserProfile)
-        .values(id=uuid.uuid4(), user_id=user_id, first_name=row["first_name"], last_name=row["last_name"], gender=Gender.UNKNOWN.value)
+        .values(id=uuid.uuid4(), user_id=user_id, first_name=first_name, last_name=last_name, preferred_name=preferred_name, gender=Gender.UNKNOWN.value)
+        .on_conflict_do_update(index_elements=["user_id"], set_=dict(first_name=first_name, last_name=last_name, preferred_name=preferred_name))
         .execute()
     )
-    click.echo(f"Created demo ministry user: {email}")
     return user_id
 
 

--- a/portal/application/cli/ministry_seed_service.py
+++ b/portal/application/cli/ministry_seed_service.py
@@ -1,0 +1,282 @@
+"""
+Demo ministry seed use case for CLI.
+
+Replaces ministries whose localized names start with the demo prefix and inserts
+Active ministries with a simulated Ministry Approval. This does not run the live
+submit / approve workflow.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+import click
+
+from portal.application.org.ministry_schedule import encode_schedule_days_mask
+from portal.cli.datas.ministry_seed_data import SEED_LOCALE_CODES, SEED_NAME_PREFIX
+from portal.domain.org.constants import MinistryApprovalStatus, MinistryMemberRole, MinistryStatus
+from portal.libs.consts.enums import Gender
+from portal.libs.database import Session
+from portal.libs.logger import logger
+from portal.models import (
+    AuthUser,
+    AuthUserProfile,
+    OrgMinistry,
+    OrgMinistryApproval,
+    OrgMinistryMember,
+    OrgMinistrySchedule,
+    OrgMinistryTargetAudience,
+    OrgMinistryTranslation,
+    OrgMinistryType,
+    OrgPosition,
+    OrgTargetAudience,
+    SystemLocale,
+)
+
+# Offset so submitted_at reads earlier than approved_at on demo detail views.
+SUBMITTED_BEFORE_APPROVED = timedelta(days=7)
+APPROVAL_COMMENT = "Simulated approval from seed-ministries"
+
+
+def assert_seed_prerequisites(
+    rows: list[dict[str, Any]], *, locale_codes: set[str], ministry_type_codes: set[str], target_audience_codes: set[str], owning_position_count: int
+) -> None:
+    """Raise a message naming the prerequisite seed command when a catalog is missing."""
+    missing_locales = sorted({code for row in rows for code in row["translations"]} - locale_codes)
+    if missing_locales:
+        raise ValueError(f"Locale(s) {', '.join(missing_locales)} not found. Run init-locales first.")
+
+    missing_types = sorted({row["ministry_type_code"] for row in rows} - ministry_type_codes)
+    if missing_types:
+        raise ValueError(f"Ministry type code(s) {', '.join(missing_types)} not found. Run seed-ministry-types first.")
+
+    missing_audiences = sorted({code for row in rows for code in row["target_audience_codes"]} - target_audience_codes)
+    if missing_audiences:
+        raise ValueError(f"Target audience code(s) {', '.join(missing_audiences)} not found. Run seed-target-audiences first.")
+
+    if owning_position_count <= 0:
+        raise ValueError("No active position with can_own_ministry found. Run seed-positions first.")
+
+
+def _as_uuid(value: Any) -> UUID:
+    return value if isinstance(value, UUID) else UUID(str(value))
+
+
+def _normalize_locale_code(locale_code: str) -> str:
+    return locale_code.strip().replace("_", "-").lower()
+
+
+def _locale_variants(locale_row: dict[str, Any]) -> set[str]:
+    language_code = (locale_row.get("language_code") or "").strip()
+    script_code = (locale_row.get("script_code") or "").strip()
+    region_code = (locale_row.get("region_code") or "").strip()
+    variants: set[str] = set()
+    if language_code:
+        variants.add(_normalize_locale_code(language_code))
+    if language_code and region_code:
+        variants.add(_normalize_locale_code(f"{language_code}-{region_code}"))
+    if language_code and script_code and region_code:
+        variants.add(_normalize_locale_code(f"{language_code}-{script_code}-{region_code}"))
+    return variants
+
+
+async def _load_locale_ids(session: Session) -> dict[str, UUID]:
+    """Map each seed locale code to an active SystemLocale id."""
+    locale_rows = await (
+        session.select(SystemLocale.id, SystemLocale.language_code, SystemLocale.region_code, SystemLocale.script_code)
+        .where(SystemLocale.is_active == True)
+        .where(SystemLocale.is_deleted == False)
+        .fetch()
+    )
+    resolved: dict[str, UUID] = {}
+    for locale_code in SEED_LOCALE_CODES:
+        normalized = _normalize_locale_code(locale_code)
+        for locale_row in locale_rows or []:
+            if normalized in _locale_variants(locale_row):
+                resolved[locale_code] = _as_uuid(locale_row["id"])
+                break
+    return resolved
+
+
+async def _load_catalog_ids_by_code(session: Session, catalog_model: type) -> dict[str, UUID]:
+    rows = await session.select(catalog_model.id, catalog_model.code).where(catalog_model.is_active == True).fetch()
+    return {str(row["code"]): _as_uuid(row["id"]) for row in rows or []}
+
+
+async def _load_owning_position_ids(session: Session) -> list[UUID]:
+    """Active positions whose office may own a ministry, in display order."""
+    position_ids = await (
+        session.select(OrgPosition.id)
+        .where(OrgPosition.can_own_ministry == True)
+        .where(OrgPosition.is_active == True)
+        .where(OrgPosition.is_deleted == False)
+        .order_by(OrgPosition.sequence)
+        .fetchvals()
+    )
+    return [_as_uuid(position_id) for position_id in position_ids or []]
+
+
+async def _ensure_demo_user(session: Session, row: dict[str, Any]) -> UUID:
+    """Return the demo steward user id, creating a non-admin account when missing."""
+    email = (row["email"] or "").strip().lower()
+    existing_id = await session.select(AuthUser.id).where(AuthUser.email == email).fetchval()
+    if existing_id:
+        # The email is unique, so a soft-deleted or deactivated demo user cannot be
+        # re-created. Restore the flags the seeded ministries rely on instead.
+        await session.update(AuthUser).values(is_active=True, verified=True, is_deleted=False).where(AuthUser.id == existing_id).execute()
+        return _as_uuid(existing_id)
+
+    user_id = uuid.uuid4()
+    await (
+        session.insert(AuthUser)
+        .values(id=user_id, email=email, password_hash=None, verified=True, is_active=True, is_superuser=False, is_admin=False)
+        .execute()
+    )
+    await (
+        session.insert(AuthUserProfile)
+        .values(id=uuid.uuid4(), user_id=user_id, first_name=row["first_name"], last_name=row["last_name"], gender=Gender.UNKNOWN.value)
+        .execute()
+    )
+    click.echo(f"Created demo ministry user: {email}")
+    return user_id
+
+
+async def _clear_seed_ministries(session: Session) -> int:
+    """Hard-delete only ministries with a demo-prefixed translation name."""
+    ministry_ids = await session.select(OrgMinistryTranslation.ministry_id).where(OrgMinistryTranslation.name.like(f"{SEED_NAME_PREFIX}%")).fetchvals()
+    unique_ids = sorted({_as_uuid(ministry_id) for ministry_id in ministry_ids or []})
+    if not unique_ids:
+        return 0
+    await session.delete(OrgMinistry).where(OrgMinistry.id.in_(unique_ids)).execute()
+    return len(unique_ids)
+
+
+async def _insert_ministry(
+    session: Session,
+    row: dict[str, Any],
+    *,
+    locale_ids: dict[str, UUID],
+    ministry_type_ids: dict[str, UUID],
+    target_audience_ids: dict[str, UUID],
+    owner_position_id: UUID,
+    primary_user_id: UUID,
+    secondary_user_id: UUID,
+    submitted_at: datetime,
+    approved_at: datetime,
+) -> None:
+    ministry_id = uuid.uuid4()
+    await (
+        session.insert(OrgMinistry)
+        .values(
+            id=ministry_id,
+            ministry_type_id=ministry_type_ids[row["ministry_type_code"]],
+            owner_position_id=owner_position_id,
+            status=MinistryStatus.ACTIVE.value,
+            is_active=True,
+            has_priority_booking=row["has_priority_booking"],
+            submitted_at=submitted_at,
+            submitted_by_id=primary_user_id,
+            approved_at=approved_at,
+            approved_by_id=secondary_user_id,
+            created_by_id=primary_user_id,
+        )
+        .execute()
+    )
+
+    for locale_code, translation in row["translations"].items():
+        await (
+            session.insert(OrgMinistryTranslation)
+            .values(
+                id=uuid.uuid4(),
+                ministry_id=ministry_id,
+                locale_id=locale_ids[locale_code],
+                name=translation["name"],
+                schedule_note=translation.get("schedule_note"),
+            )
+            .execute()
+        )
+
+    for member_role, user_id in ((MinistryMemberRole.PRIMARY, primary_user_id), (MinistryMemberRole.SECONDARY, secondary_user_id)):
+        await session.insert(OrgMinistryMember).values(id=uuid.uuid4(), ministry_id=ministry_id, user_id=user_id, member_role=member_role.value).execute()
+
+    for index, schedule in enumerate(row["schedules"]):
+        await (
+            session.insert(OrgMinistrySchedule)
+            .values(
+                id=uuid.uuid4(),
+                ministry_id=ministry_id,
+                days_of_week_mask=encode_schedule_days_mask(schedule["days_of_week"]),
+                start_time=schedule["start_time"],
+                end_time=schedule["end_time"],
+                effective_from=schedule["effective_from"],
+                effective_to=schedule["effective_to"],
+                sequence=float(index),
+            )
+            .execute()
+        )
+
+    for audience_code in row["target_audience_codes"]:
+        await (
+            session.insert(OrgMinistryTargetAudience)
+            .values(id=uuid.uuid4(), ministry_id=ministry_id, target_audience_id=target_audience_ids[audience_code])
+            .execute()
+        )
+
+    await (
+        session.insert(OrgMinistryApproval)
+        .values(
+            id=uuid.uuid4(),
+            ministry_id=ministry_id,
+            owner_position_id=owner_position_id,
+            status=MinistryApprovalStatus.APPROVED.value,
+            requested_by_id=primary_user_id,
+            resolved_by_id=secondary_user_id,
+            decided_at=approved_at,
+            comment=APPROVAL_COMMENT,
+        )
+        .execute()
+    )
+
+
+async def run_ministry_seed(session: Session, rows: list[dict[str, Any]], *, demo_user_rows: list[dict[str, Any]]) -> None:
+    """Replace demo ministries and insert Active ministries with a simulated approval."""
+    locale_ids = await _load_locale_ids(session)
+    ministry_type_ids = await _load_catalog_ids_by_code(session, OrgMinistryType)
+    target_audience_ids = await _load_catalog_ids_by_code(session, OrgTargetAudience)
+    owning_position_ids = await _load_owning_position_ids(session)
+
+    assert_seed_prerequisites(
+        rows,
+        locale_codes=set(locale_ids),
+        ministry_type_codes=set(ministry_type_ids),
+        target_audience_codes=set(target_audience_ids),
+        owning_position_count=len(owning_position_ids),
+    )
+
+    primary_user_id = await _ensure_demo_user(session, demo_user_rows[0])
+    secondary_user_id = await _ensure_demo_user(session, demo_user_rows[1])
+
+    deleted = await _clear_seed_ministries(session)
+
+    approved_at = datetime.now(tz=timezone.utc)
+    submitted_at = approved_at - SUBMITTED_BEFORE_APPROVED
+
+    for index, row in enumerate(rows):
+        await _insert_ministry(
+            session,
+            row,
+            locale_ids=locale_ids,
+            ministry_type_ids=ministry_type_ids,
+            target_audience_ids=target_audience_ids,
+            owner_position_id=owning_position_ids[index % len(owning_position_ids)],
+            primary_user_id=primary_user_id,
+            secondary_user_id=secondary_user_id,
+            submitted_at=submitted_at,
+            approved_at=approved_at,
+        )
+
+    await session.commit()
+    summary = f"Ministry seed done: {len(rows)} ministry(ies) inserted, {deleted} demo ministry(ies) replaced"
+    click.echo(click.style(summary, fg="green"))
+    logger.info(summary)

--- a/portal/cli/datas/ministry_seed_data.py
+++ b/portal/cli/datas/ministry_seed_data.py
@@ -1,0 +1,175 @@
+"""
+Demo ministry seed data.
+
+Every localized name carries the ``seed: Demo `` prefix so the seed command can
+replace only demo ministries and leave admin-created ministries untouched.
+
+Ministry Type and target audience are referenced by stable catalog code, not by
+localized name. Alpha 2026 is an Annual Ministry: one record per year with the
+year in the name. Weekly programs that pause for a season keep a single ministry
+and bound the weekly pattern with a Seasonal schedule instead.
+"""
+
+from datetime import date, time
+from typing import Any, Optional
+
+from portal.domain.facility.constants import DayOfWeek
+from portal.domain.org.catalog_codes import (
+    MINISTRY_TYPE_INTERNAL,
+    MINISTRY_TYPE_OUTREACH,
+    MINISTRY_TYPE_WORSHIP,
+    TARGET_AUDIENCE_ADULTS,
+    TARGET_AUDIENCE_ALL_AGES,
+    TARGET_AUDIENCE_CHILDREN,
+    TARGET_AUDIENCE_FAMILY,
+    TARGET_AUDIENCE_YOUTHS,
+)
+
+SEED_NAME_PREFIX = "seed: Demo "
+SEED_LOCALE_CODES = ("en", "zh-TW", "zh-CN")
+
+DEMO_PRIMARY_USER_EMAIL = "seed.ministry.primary@local.test"
+DEMO_SECONDARY_USER_EMAIL = "seed.ministry.secondary@local.test"
+
+demo_ministry_user_seed_rows: list[dict[str, Any]] = [
+    {"email": DEMO_PRIMARY_USER_EMAIL, "first_name": "Seed", "last_name": "Primary"},
+    {"email": DEMO_SECONDARY_USER_EMAIL, "first_name": "Seed", "last_name": "Secondary"},
+]
+
+# Demo calendar year is 2026.
+SUMMER_FROM = date(2026, 6, 1)
+SUMMER_TO = date(2026, 8, 31)
+SCHOOL_YEAR_FROM = date(2026, 9, 1)
+SCHOOL_YEAR_TO = date(2027, 5, 31)
+ALPHA_FROM = date(2026, 9, 1)
+ALPHA_TO = date(2026, 9, 30)
+
+
+def _schedule(
+    *,
+    days_of_week: Optional[list[int]] = None,
+    start_time: Optional[time] = None,
+    end_time: Optional[time] = None,
+    effective_from: Optional[date] = None,
+    effective_to: Optional[date] = None,
+) -> dict[str, Any]:
+    """Build one schedule row. Empty start/end times mean the time is TBA."""
+    return {
+        "days_of_week": list(days_of_week or []),
+        "start_time": start_time,
+        "end_time": end_time,
+        "effective_from": effective_from,
+        "effective_to": effective_to,
+    }
+
+
+def _translation(name: str, schedule_note: Optional[str] = None) -> dict[str, Any]:
+    """Build one localized row, prefixing the name so demo rows stay recognizable."""
+    return {"name": f"{SEED_NAME_PREFIX}{name}", "schedule_note": schedule_note}
+
+
+def _ministry(
+    *,
+    ministry_type_code: str,
+    target_audience_codes: list[str],
+    translations: dict[str, dict[str, Any]],
+    schedules: list[dict[str, Any]],
+    has_priority_booking: bool = False,
+) -> dict[str, Any]:
+    return {
+        "ministry_type_code": ministry_type_code,
+        "target_audience_codes": list(target_audience_codes),
+        "has_priority_booking": has_priority_booking,
+        "translations": translations,
+        "schedules": schedules,
+    }
+
+
+ministry_seed_rows: list[dict[str, Any]] = [
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_OUTREACH,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS],
+        has_priority_booking=True,
+        translations={"en": _translation("Alpha 2026", "Sept"), "zh-TW": _translation("啟發 2026", "九月"), "zh-CN": _translation("启发 2026", "九月")},
+        schedules=[_schedule(effective_from=ALPHA_FROM, effective_to=ALPHA_TO)],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS],
+        has_priority_booking=True,
+        translations={"en": _translation("Badminton"), "zh-TW": _translation("羽毛球"), "zh-CN": _translation("羽毛球")},
+        schedules=[_schedule(days_of_week=[DayOfWeek.SUNDAY], start_time=time(13, 30), end_time=time(16, 30))],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_CHILDREN, TARGET_AUDIENCE_YOUTHS],
+        translations={"en": _translation("Basketball"), "zh-TW": _translation("籃球"), "zh-CN": _translation("篮球")},
+        schedules=[_schedule(days_of_week=[DayOfWeek.SATURDAY], start_time=time(14, 0), end_time=time(18, 0))],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_CHILDREN, TARGET_AUDIENCE_ADULTS],
+        translations={
+            "en": _translation("Chinese School", "Adults: conversation class only"),
+            "zh-TW": _translation("中文學校", "成人僅會話班"),
+            "zh-CN": _translation("中文学校", "成人仅会话班"),
+        },
+        schedules=[
+            _schedule(
+                days_of_week=[DayOfWeek.SATURDAY], start_time=time(14, 0), end_time=time(16, 0), effective_from=SCHOOL_YEAR_FROM, effective_to=SCHOOL_YEAR_TO
+            )
+        ],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS],
+        translations={"en": _translation("Pickleball"), "zh-TW": _translation("皮克球"), "zh-CN": _translation("皮克球")},
+        schedules=[_schedule(days_of_week=[DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY], start_time=time(9, 30), end_time=time(12, 0))],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_ALL_AGES],
+        translations={"en": _translation("Softball"), "zh-TW": _translation("壘球"), "zh-CN": _translation("垒球")},
+        schedules=[
+            _schedule(
+                days_of_week=[DayOfWeek.SATURDAY, DayOfWeek.SUNDAY],
+                start_time=time(15, 0),
+                end_time=time(18, 0),
+                effective_from=SUMMER_FROM,
+                effective_to=SUMMER_TO,
+            )
+        ],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS],
+        translations={"en": _translation("Stretching"), "zh-TW": _translation("拉筋班"), "zh-CN": _translation("拉筋班")},
+        schedules=[
+            _schedule(
+                days_of_week=[DayOfWeek.THURSDAY], start_time=time(20, 30), end_time=time(21, 30), effective_from=SCHOOL_YEAR_FROM, effective_to=SCHOOL_YEAR_TO
+            )
+        ],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_OUTREACH,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS, TARGET_AUDIENCE_FAMILY],
+        translations={
+            "en": _translation("Supporting SOSO Ministry", "Or special occasion"),
+            "zh-TW": _translation("支援 SOSO 事工", "或特殊節日"),
+            "zh-CN": _translation("支援 SOSO 事工", "或特殊节日"),
+        },
+        schedules=[_schedule(days_of_week=[DayOfWeek.MONDAY], start_time=time(10, 0), end_time=time(15, 0))],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_WORSHIP,
+        target_audience_codes=[TARGET_AUDIENCE_ALL_AGES],
+        translations={"en": _translation("Choir"), "zh-TW": _translation("詩班"), "zh-CN": _translation("诗班")},
+        schedules=[_schedule(days_of_week=[DayOfWeek.SUNDAY], start_time=time(9, 0), end_time=time(10, 30))],
+    ),
+    _ministry(
+        ministry_type_code=MINISTRY_TYPE_INTERNAL,
+        target_audience_codes=[TARGET_AUDIENCE_ADULTS],
+        translations={"en": _translation("Prayer"), "zh-TW": _translation("禱告"), "zh-CN": _translation("祷告")},
+        schedules=[_schedule(days_of_week=[DayOfWeek.WEDNESDAY], start_time=time(19, 30), end_time=time(21, 0))],
+    ),
+]

--- a/portal/cli/main.py
+++ b/portal/cli/main.py
@@ -8,6 +8,7 @@ from .init_locale import init_locales_process
 from .rbac import init_rbac_process, reset_rbac_process
 from .seed_facility_rental import seed_facility_rental_process
 from .seed_facility_slots import seed_facility_slots_process
+from .seed_ministry import seed_ministries_process
 from .seed_ministry_type import seed_ministry_types_process
 from .seed_position import seed_positions_process
 from .seed_position_assignment import seed_position_assignments_process
@@ -66,6 +67,13 @@ def seed_position_assignments_cmd(force: bool):
 def seed_ministry_types_cmd(force: bool):
     """Seed org ministry types with multilingual translations."""
     seed_ministry_types_process(force=force)
+
+
+@cli.command(name="seed-ministries")
+@click.option("--force", is_flag=True, default=False, help="Skip confirmation and allow running when ENV is prod or stg.")
+def seed_ministries_cmd(force: bool):
+    """Seed ten demo Active ministries with a simulated approval."""
+    seed_ministries_process(force=force)
 
 
 @cli.command(name="seed-target-audiences")

--- a/portal/cli/seed_ministry.py
+++ b/portal/cli/seed_ministry.py
@@ -1,0 +1,55 @@
+"""
+Demo ministry seed CLI commands.
+"""
+
+import asyncio
+
+import click
+
+from portal.application.cli.ministry_seed_service import run_ministry_seed
+from portal.config import settings
+from portal.container import Container
+from portal.libs.logger import logger
+
+from .datas.ministry_seed_data import demo_ministry_user_seed_rows, ministry_seed_rows
+
+
+async def seed_ministries() -> None:
+    """Seed demo Active ministries with a simulated approval."""
+    container = Container()
+    session = container.db_session()
+    try:
+        await run_ministry_seed(session, ministry_seed_rows, demo_user_rows=demo_ministry_user_seed_rows)
+    except Exception as error:
+        await session.rollback()
+        click.echo(click.style(f"Ministry seed failed: {error}", fg="red"))
+        logger.exception(error)
+        raise
+    finally:
+        await session.close()
+
+
+def seed_ministries_process(*, force: bool = False) -> None:
+    """Synchronous entry to run the demo ministry seed."""
+    if not settings.IS_DEV and not force:
+        click.echo(click.style(f"seed-ministries is blocked when ENV={settings.ENV!r}. Pass --force to proceed.", fg="red"))
+        raise SystemExit(1)
+
+    if not force:
+        click.echo(
+            click.style(
+                "WARNING: This replaces demo ministries whose localized names start with "
+                "'seed: Demo ' (hard delete + re-insert). Admin-created ministries without "
+                "that prefix are left untouched. Locales, ministry types, target audiences, "
+                "and positions that can own a ministry must already exist (init-locales, "
+                "seed-ministry-types, seed-target-audiences, seed-positions).",
+                fg="yellow",
+            )
+        )
+        if not click.confirm("Continue?", default=False):
+            click.echo("Aborted.")
+            raise SystemExit(0)
+
+    click.echo(click.style("Seeding demo ministries...", fg="cyan"))
+    asyncio.run(seed_ministries())
+    click.echo(click.style("Done.", fg="green"))

--- a/tests/application/cli/test_ministry_seed_data.py
+++ b/tests/application/cli/test_ministry_seed_data.py
@@ -1,0 +1,254 @@
+"""
+Tests for the demo ministry seed rows and seed prerequisite checks.
+"""
+
+from datetime import date, time
+
+import pytest
+
+from portal.application.cli.ministry_seed_service import assert_seed_prerequisites
+from portal.cli.datas.ministry_seed_data import (
+    DEMO_PRIMARY_USER_EMAIL,
+    DEMO_SECONDARY_USER_EMAIL,
+    SEED_LOCALE_CODES,
+    SEED_NAME_PREFIX,
+    demo_ministry_user_seed_rows,
+    ministry_seed_rows,
+)
+from portal.domain.facility.constants import DayOfWeek
+from portal.domain.org.catalog_codes import (
+    MINISTRY_TYPE_INTERNAL,
+    MINISTRY_TYPE_OUTREACH,
+    MINISTRY_TYPE_WORSHIP,
+    TARGET_AUDIENCE_ADULTS,
+    TARGET_AUDIENCE_ALL_AGES,
+    TARGET_AUDIENCE_CHILDREN,
+    TARGET_AUDIENCE_FAMILY,
+    TARGET_AUDIENCE_YOUTHS,
+)
+
+
+def _row_by_english_name(name: str) -> dict:
+    """Look up a seed row by its unprefixed English name."""
+    full_name = f"{SEED_NAME_PREFIX}{name}"
+    for row in ministry_seed_rows:
+        if row["translations"]["en"]["name"] == full_name:
+            return row
+    raise AssertionError(f"seed row {name!r} not found")
+
+
+def test_seed_defines_ten_ministries():
+    assert len(ministry_seed_rows) == 10
+
+
+def test_every_locale_name_starts_with_seed_prefix():
+    for row in ministry_seed_rows:
+        for locale_code in SEED_LOCALE_CODES:
+            name = row["translations"][locale_code]["name"]
+            assert name.startswith(SEED_NAME_PREFIX), f"{locale_code} name {name!r} missing prefix"
+
+
+def test_every_ministry_has_all_three_locales():
+    for row in ministry_seed_rows:
+        assert set(row["translations"]) == set(SEED_LOCALE_CODES)
+
+
+def test_english_names_match_the_frozen_program_table():
+    english_names = [row["translations"]["en"]["name"] for row in ministry_seed_rows]
+    assert english_names == [
+        f"{SEED_NAME_PREFIX}{name}"
+        for name in [
+            "Alpha 2026",
+            "Badminton",
+            "Basketball",
+            "Chinese School",
+            "Pickleball",
+            "Softball",
+            "Stretching",
+            "Supporting SOSO Ministry",
+            "Choir",
+            "Prayer",
+        ]
+    ]
+
+
+@pytest.mark.parametrize(
+    "locale_code,expected",
+    [
+        ("zh-TW", ["啟發 2026", "羽毛球", "籃球", "中文學校", "皮克球", "壘球", "拉筋班", "支援 SOSO 事工", "詩班", "禱告"]),
+        ("zh-CN", ["启发 2026", "羽毛球", "篮球", "中文学校", "皮克球", "垒球", "拉筋班", "支援 SOSO 事工", "诗班", "祷告"]),
+    ],
+)
+def test_localized_names_match_the_frozen_program_table(locale_code: str, expected: list[str]):
+    names = [row["translations"][locale_code]["name"] for row in ministry_seed_rows]
+    assert names == [f"{SEED_NAME_PREFIX}{name}" for name in expected]
+
+
+def test_only_alpha_and_badminton_have_priority_booking():
+    flags = [row["has_priority_booking"] for row in ministry_seed_rows]
+    assert flags == [True, True, False, False, False, False, False, False, False, False]
+
+
+def test_alpha_is_an_annual_ministry_with_september_window_and_tba_times():
+    row = _row_by_english_name("Alpha 2026")
+
+    assert "2026" in row["translations"]["en"]["name"]
+    assert "2026" in row["translations"]["zh-TW"]["name"]
+    assert "2026" in row["translations"]["zh-CN"]["name"]
+
+    assert len(row["schedules"]) == 1
+    schedule = row["schedules"][0]
+    assert schedule["start_time"] is None
+    assert schedule["end_time"] is None
+    assert schedule["effective_from"] == date(2026, 9, 1)
+    assert schedule["effective_to"] == date(2026, 9, 30)
+    assert row["ministry_type_code"] == MINISTRY_TYPE_OUTREACH
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_ADULTS]
+
+
+def test_choir_is_a_worship_ministry_on_sunday_morning():
+    row = _row_by_english_name("Choir")
+
+    assert row["ministry_type_code"] == MINISTRY_TYPE_WORSHIP
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_ALL_AGES]
+    assert row["schedules"] == [
+        {"days_of_week": [DayOfWeek.SUNDAY], "start_time": time(9, 0), "end_time": time(10, 30), "effective_from": None, "effective_to": None}
+    ]
+
+
+def test_prayer_is_a_wednesday_evening_ministry():
+    row = _row_by_english_name("Prayer")
+
+    assert row["ministry_type_code"] == MINISTRY_TYPE_INTERNAL
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_ADULTS]
+    assert row["schedules"] == [
+        {"days_of_week": [DayOfWeek.WEDNESDAY], "start_time": time(19, 30), "end_time": time(21, 0), "effective_from": None, "effective_to": None}
+    ]
+
+
+def test_basketball_targets_children_and_youths_on_saturday_afternoon():
+    row = _row_by_english_name("Basketball")
+
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_CHILDREN, TARGET_AUDIENCE_YOUTHS]
+    assert row["schedules"][0]["days_of_week"] == [DayOfWeek.SATURDAY]
+    assert row["schedules"][0]["start_time"] == time(14, 0)
+    assert row["schedules"][0]["end_time"] == time(18, 0)
+
+
+def test_pickleball_runs_three_weekdays():
+    row = _row_by_english_name("Pickleball")
+
+    assert row["schedules"][0]["days_of_week"] == [DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY]
+    assert row["schedules"][0]["start_time"] == time(9, 30)
+    assert row["schedules"][0]["end_time"] == time(12, 0)
+
+
+def test_softball_uses_a_summer_only_seasonal_schedule():
+    row = _row_by_english_name("Softball")
+
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_ALL_AGES]
+    schedule = row["schedules"][0]
+    assert schedule["days_of_week"] == [DayOfWeek.SATURDAY, DayOfWeek.SUNDAY]
+    assert schedule["start_time"] == time(15, 0)
+    assert schedule["end_time"] == time(18, 0)
+    assert schedule["effective_from"] == date(2026, 6, 1)
+    assert schedule["effective_to"] == date(2026, 8, 31)
+
+
+@pytest.mark.parametrize("english_name", ["Chinese School", "Stretching"])
+def test_summer_except_programs_use_a_school_year_seasonal_schedule(english_name: str):
+    row = _row_by_english_name(english_name)
+
+    schedule = row["schedules"][0]
+    assert schedule["effective_from"] == date(2026, 9, 1)
+    assert schedule["effective_to"] == date(2027, 5, 31)
+
+
+def test_chinese_school_keeps_the_adult_conversation_caveat_in_every_locale():
+    row = _row_by_english_name("Chinese School")
+
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_CHILDREN, TARGET_AUDIENCE_ADULTS]
+    for locale_code in SEED_LOCALE_CODES:
+        assert row["translations"][locale_code]["schedule_note"]
+
+
+def test_soso_keeps_a_monday_window_plus_a_special_occasion_note():
+    row = _row_by_english_name("Supporting SOSO Ministry")
+
+    assert row["ministry_type_code"] == MINISTRY_TYPE_OUTREACH
+    assert row["target_audience_codes"] == [TARGET_AUDIENCE_ADULTS, TARGET_AUDIENCE_FAMILY]
+    schedule = row["schedules"][0]
+    assert schedule["days_of_week"] == [DayOfWeek.MONDAY]
+    assert schedule["start_time"] == time(10, 0)
+    assert schedule["end_time"] == time(15, 0)
+    for locale_code in SEED_LOCALE_CODES:
+        assert row["translations"][locale_code]["schedule_note"]
+
+
+def test_badminton_runs_sunday_afternoon():
+    row = _row_by_english_name("Badminton")
+
+    assert row["schedules"][0]["days_of_week"] == [DayOfWeek.SUNDAY]
+    assert row["schedules"][0]["start_time"] == time(13, 30)
+    assert row["schedules"][0]["end_time"] == time(16, 30)
+
+
+def test_all_ages_is_never_combined_with_another_audience():
+    for row in ministry_seed_rows:
+        codes = row["target_audience_codes"]
+        if TARGET_AUDIENCE_ALL_AGES in codes:
+            assert codes == [TARGET_AUDIENCE_ALL_AGES]
+
+
+def test_every_schedule_has_a_weekday_or_an_effective_window():
+    for row in ministry_seed_rows:
+        assert row["schedules"], row["translations"]["en"]["name"]
+        for schedule in row["schedules"]:
+            assert schedule["days_of_week"] or schedule["effective_from"]
+            assert (schedule["start_time"] is None) == (schedule["end_time"] is None)
+            if schedule["start_time"] and schedule["end_time"]:
+                assert schedule["start_time"] < schedule["end_time"]
+
+
+def test_demo_users_are_two_non_admin_stewards():
+    assert [row["email"] for row in demo_ministry_user_seed_rows] == [DEMO_PRIMARY_USER_EMAIL, DEMO_SECONDARY_USER_EMAIL]
+    assert DEMO_PRIMARY_USER_EMAIL == "seed.ministry.primary@local.test"
+    assert DEMO_SECONDARY_USER_EMAIL == "seed.ministry.secondary@local.test"
+    for row in demo_ministry_user_seed_rows:
+        assert row["first_name"]
+        assert row["last_name"]
+
+
+def _prerequisites(**overrides):
+    kwargs = dict(
+        locale_codes=set(SEED_LOCALE_CODES),
+        ministry_type_codes={MINISTRY_TYPE_OUTREACH, MINISTRY_TYPE_INTERNAL, MINISTRY_TYPE_WORSHIP},
+        target_audience_codes={TARGET_AUDIENCE_CHILDREN, TARGET_AUDIENCE_YOUTHS, TARGET_AUDIENCE_ADULTS, TARGET_AUDIENCE_FAMILY, TARGET_AUDIENCE_ALL_AGES},
+        owning_position_count=3,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_prerequisites_pass_when_every_catalog_is_seeded():
+    assert_seed_prerequisites(ministry_seed_rows, **_prerequisites())
+
+
+def test_missing_locale_names_the_locale_seed():
+    with pytest.raises(ValueError, match="init-locales"):
+        assert_seed_prerequisites(ministry_seed_rows, **_prerequisites(locale_codes={"en"}))
+
+
+def test_missing_ministry_type_names_the_ministry_type_seed():
+    with pytest.raises(ValueError, match="seed-ministry-types"):
+        assert_seed_prerequisites(ministry_seed_rows, **_prerequisites(ministry_type_codes={MINISTRY_TYPE_INTERNAL}))
+
+
+def test_missing_target_audience_names_the_target_audience_seed():
+    with pytest.raises(ValueError, match="seed-target-audiences"):
+        assert_seed_prerequisites(ministry_seed_rows, **_prerequisites(target_audience_codes={TARGET_AUDIENCE_ADULTS}))
+
+
+def test_missing_owning_position_names_the_position_seed():
+    with pytest.raises(ValueError, match="seed-positions"):
+        assert_seed_prerequisites(ministry_seed_rows, **_prerequisites(owning_position_count=0))


### PR DESCRIPTION
## Summary

Fresh local and shared-dev databases have catalog seeds for Ministry Type, target audience, and position, but no Ministry records — so admin ministry lists and booking pickers that filter to **Active** are empty unless someone clicks through create/submit/approve by hand. This adds a repeatable `seed-ministries` CLI command that inserts ten **Active** ministries with a simulated **Ministry Approval**, two demo stewards, rotating owner positions, schedules, and target audiences. Re-runs hard-delete and replace only ministries whose localized names start with `seed: Demo `, leaving admin-created ministries and the demo users in place.

Closes #61

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Follows the existing demo-seed shape: declarative rows in `portal/cli/datas/`, an application use case in `portal/application/cli/`, and a thin Click wrapper whose dev gate / warning / confirm / `--force` UX matches `seed-facility-slots`.

- **No live workflow.** The seed stamps `status=active`, `is_active`, `submitted_at/by`, `approved_at/by`, and one approved `OrgMinistryApproval` row directly. It never calls `MinistryService` submit/approve, so it does not depend on request context or member-validation side effects.
- **Fail fast** when a prerequisite catalog is missing, naming the command to run: `init-locales`, `seed-ministry-types`, `seed-target-audiences`, `seed-positions`. `assert_seed_prerequisites` is a pure function, so this is covered without a database.
- **Annual Ministry vs Seasonal schedule.** Alpha 2026 is the annual example (year in the name, September 2026 window, TBA times). Chinese School / Stretching / Softball stay one ministry each and bound the weekly pattern with `effective_from` / `effective_to`.
- **Glossary.** Issue #61 states these terms are already in the domain glossary, but `CONTEXT.md` only carried facility-booking terms. Added **Annual Ministry** and **Seasonal schedule** (user stories 26 and 32). The other five terms the issue names are still absent; no story required them.
- **Follow-up, not done here.** The locale-code resolution helper is now a third near-verbatim copy alongside `position_seed_service.py` and `catalog_seed_service.py`. Extracting a shared helper means touching two unrelated seeds, so it is left out of this PR.

## Testing

- [x] `uv run pytest` — 259 passed (26 new)
- [x] `uv run ruff format` then `uv run ruff check --fix` — clean
- [x] Ran `seed-ministries` against a local dev database end to end:
  - Fail-fast path before catalogs exist: `Ministry type code(s) internal, outreach, worship not found. Run seed-ministry-types first.`
  - First run inserted 10; re-run reported `10 inserted, 10 replaced` and reused the demo users instead of recreating them.
  - A hand-built ministry without the prefix survived the re-run.
  - Verified per column: all `status=active` with `submitted_at` before `approved_at`, 10 distinct owner positions, 30 translations (3 locales each, every name prefixed), 20 members (one primary + one secondary per ministry, same two users), 10 approved approval rows, 13 target-audience links, Alpha the only TBA schedule, 3 seasonal windows.
  - Soft-deleting a demo steward and re-running restored it rather than leaving Active ministries attached to a dead account.

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge — note: this repo has no `.github/workflows`, so the checks above are local only

Made with [Cursor](https://cursor.com)