### PR TITLE
feat: add steward directory query for ministry admin

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,18 @@ _Avoid_: scheduling conflict, "closed" without naming the Blackout rule
 
 ### Org / ministry
 
+**Ministry Steward**:
+A user assigned to a Ministry as `primary` or `secondary` (`org.ministry_member`). This is who may represent the Ministry. It is not a pastoral Person record and not the facility-booking priority-member identity.
+_Avoid_: Ministry Member (when meaning booking priority), Member Person, owner (Position incumbent)
+
+**Steward roster**:
+The full set of Ministry Stewards for one Ministry. Domain rule: exactly one primary steward and at least one secondary steward.
+_Avoid_: treating primary/secondary as auth.role or org.position
+
+**Steward directory query**:
+A query whose result is Ministries, not membership rows. It may match a Ministry name or a Steward's display name/email. A match does not return the Steward roster; the roster loads for the selected Ministry.
+_Avoid_: one row per steward, treating this as Member Person search, stuffing the roster into the directory payload
+
 **Annual Ministry**:
 A ministry that runs as one distinct edition per year, with the year in its name (e.g. Alpha 2026). Next year's edition is a **new** Ministry record, not the same row with shifted dates, so each year keeps its own approval, stewards, and history.
 _Avoid_: recycling last year's row by editing its dates, treating the year as a Seasonal schedule bound

--- a/docs/adr/0004-steward-directory-query.md
+++ b/docs/adr/0004-steward-directory-query.md
@@ -1,0 +1,18 @@
+# Steward directory query is not ministry pages keyword
+
+Admin operators need to find which Ministries a person stewards without opening each Ministry, but the Steward roster write model stays one Ministry at a time. We add a **Steward directory query**: the result is Ministries (not membership rows). A `q` may match Ministry name or a Steward's display name / email. The payload does **not** include the Steward roster; clients load the roster from existing Ministry detail.
+
+We do **not** extend generic ministry `pages` `keyword` (translation name only). That list is Ministry CRUD search. Mixing steward identity into it would make the Ministries page silently find people.
+
+## Considered Options
+
+- **Embed steward summaries on every list/pages row** — rejected: larger payload and a second copy of the roster next to detail; the Portal landing only needs names in the rail after a click.
+- **N+1 GET detail for client-side person search** — rejected: slow and brittle as Ministry count grows.
+- **Reuse `keyword` on GET pages** — rejected: Ministry CRUD would start matching people.
+- **Membership-row list API** — rejected: the domain write is still replace-one-roster; a person×Ministry table fights that grain.
+
+## Consequences
+
+- Directory and detail stay different reads. Tests of directory query must not assume `members` on the items.
+- Portal (and any other admin client) must call the dedicated directory query, then GET detail for the selected Ministry.
+- `GET .../ministries/list` stays the active-only picker; it is not the steward directory (it omits draft / pending / inactive / rejected).

--- a/portal/application/org/commands.py
+++ b/portal/application/org/commands.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, model_validator
 
 from portal.application.rbac.commands import BulkIdsCommand, DeleteCommand, PagesQueryCommand
-from portal.domain.org.constants import MinistryMemberRole, PositionOffice, PositionTeam
+from portal.domain.org.constants import MinistryMemberRole, MinistryStatus, PositionOffice, PositionTeam
 
 __all__ = [
     "ApproveMinistryCommand",
@@ -28,6 +28,7 @@ __all__ = [
     "PositionTranslationCommand",
     "RejectMinistryCommand",
     "ReplaceMinistryMembersCommand",
+    "StewardDirectoryQueryCommand",
     "SubmitMinistryCommand",
     "UpdateMemberPersonCommand",
     "UpdateMinistryCommand",
@@ -91,6 +92,15 @@ class UpdateMinistryCommand(BaseModel):
     is_active: bool = Field(default=True)
     sequence: Optional[float] = Field(default=None)
     translations: Optional[list[OrgTranslationCommand]] = Field(default=None)
+
+
+class StewardDirectoryQueryCommand(BaseModel):
+    """Paginated steward directory query (ministries, not membership rows)."""
+
+    page: int = Field(default=0)
+    page_size: int = Field(default=10)
+    q: Optional[str] = Field(default=None)
+    status: Optional[MinistryStatus] = Field(default=None)
 
 
 class MinistryMemberEntryCommand(BaseModel):

--- a/portal/application/org/commands.py
+++ b/portal/application/org/commands.py
@@ -101,6 +101,8 @@ class StewardDirectoryQueryCommand(BaseModel):
     page_size: int = Field(default=10)
     q: Optional[str] = Field(default=None)
     status: Optional[MinistryStatus] = Field(default=None)
+    order_by: Optional[str] = Field(default=None)
+    descending: bool = Field(default=False)
 
 
 class MinistryMemberEntryCommand(BaseModel):

--- a/portal/application/org/mappers.py
+++ b/portal/application/org/mappers.py
@@ -21,6 +21,7 @@ from portal.application.org.commands import (
     PositionTranslationCommand,
     RejectMinistryCommand,
     ReplaceMinistryMembersCommand,
+    StewardDirectoryQueryCommand,
     UpdateMemberPersonCommand,
     UpdateMinistryCommand,
     UpdatePositionCommand,
@@ -40,6 +41,7 @@ from portal.application.org.results import (
     PositionDetailResult,
     PositionPageResult,
     PositionTranslationItemResult,
+    StewardDirectoryPageResult,
     TargetAudienceListResult,
     TargetAudienceResult,
     TranslationItemResult,
@@ -48,6 +50,7 @@ from portal.domain.common.mixins import UUIDBaseModel
 from portal.serializers.admin.v1.ministry import (
     AdminMinistryApplicationCreate,
     AdminMinistryApprove,
+    AdminMinistryBase,
     AdminMinistryBulkAction,
     AdminMinistryCreate,
     AdminMinistryDetail,
@@ -59,7 +62,9 @@ from portal.serializers.admin.v1.ministry import (
     AdminMinistryReplaceMembers,
     AdminMinistryScheduleInput,
     AdminMinistryScheduleItem,
+    AdminMinistryStewardDirectoryPages,
     AdminMinistryUpdate,
+    AdminStewardDirectoryQuery,
 )
 from portal.serializers.admin.v1.ministry_catalog import AdminMinistryTypeItem, AdminMinistryTypeList, AdminTargetAudienceItem, AdminTargetAudienceList
 from portal.serializers.admin.v1.org.member_person import (
@@ -92,6 +97,10 @@ def pages_query_to_command(model: GenericQueryBaseModel) -> PagesQueryCommand:
     return PagesQueryCommand(
         page=model.page, page_size=model.page_size, order_by=model.order_by, descending=model.descending, deleted=model.deleted, keyword=model.keyword
     )
+
+
+def steward_directory_query_to_command(model: AdminStewardDirectoryQuery) -> StewardDirectoryQueryCommand:
+    return StewardDirectoryQueryCommand(page=model.page, page_size=model.page_size, q=model.q, status=model.status)
 
 
 def delete_model_to_command(model: DeleteBaseModel) -> DeleteCommand:
@@ -293,6 +302,26 @@ def ministry_list_to_api(result: MinistryListResult) -> AdminMinistryList:
             )
             for item in result.items
         ]
+    )
+
+
+def steward_directory_to_api(result: StewardDirectoryPageResult) -> AdminMinistryStewardDirectoryPages:
+    return AdminMinistryStewardDirectoryPages(
+        page=result.page,
+        page_size=result.page_size,
+        total=result.total,
+        items=[
+            AdminMinistryBase(
+                id=item.id,
+                name=item.name,
+                status=item.status,
+                has_priority_booking=item.has_priority_booking,
+                is_active=item.is_active,
+                ministry_type=_ministry_type_to_api(item.ministry_type),
+                target_audiences=_target_audiences_to_api(item.target_audiences),
+            )
+            for item in result.items
+        ],
     )
 
 

--- a/portal/application/org/mappers.py
+++ b/portal/application/org/mappers.py
@@ -100,7 +100,9 @@ def pages_query_to_command(model: GenericQueryBaseModel) -> PagesQueryCommand:
 
 
 def steward_directory_query_to_command(model: AdminStewardDirectoryQuery) -> StewardDirectoryQueryCommand:
-    return StewardDirectoryQueryCommand(page=model.page, page_size=model.page_size, q=model.q, status=model.status)
+    return StewardDirectoryQueryCommand(
+        page=model.page, page_size=model.page_size, q=model.q, status=model.status, order_by=model.order_by, descending=model.descending
+    )
 
 
 def delete_model_to_command(model: DeleteBaseModel) -> DeleteCommand:
@@ -319,6 +321,8 @@ def steward_directory_to_api(result: StewardDirectoryPageResult) -> AdminMinistr
                 is_active=item.is_active,
                 ministry_type=_ministry_type_to_api(item.ministry_type),
                 target_audiences=_target_audiences_to_api(item.target_audiences),
+                created_at=item.created_at,
+                updated_at=item.updated_at,
             )
             for item in result.items
         ],

--- a/portal/application/org/ministry_service.py
+++ b/portal/application/org/ministry_service.py
@@ -12,10 +12,18 @@ from portal.application.org.commands import (
     DeleteCommand,
     PagesQueryCommand,
     ReplaceMinistryMembersCommand,
+    StewardDirectoryQueryCommand,
     UpdateMinistryCommand,
 )
 from portal.application.org.ministry_schedule import build_schedule_payloads, validate_ministry_schedules
-from portal.application.org.results import CreateIdResult, MinistryDetailResult, MinistryListResult, MinistryMemberResult, MinistryPageResult
+from portal.application.org.results import (
+    CreateIdResult,
+    MinistryDetailResult,
+    MinistryListResult,
+    MinistryMemberResult,
+    MinistryPageResult,
+    StewardDirectoryPageResult,
+)
 from portal.application.org.target_audience_validation import validate_target_audience_ids
 from portal.domain.org.catalog_codes import MINISTRY_TYPE_INTERNAL
 from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
@@ -105,6 +113,11 @@ class MinistryService:
     async def get_ministry_list(self) -> MinistryListResult:
         items = await self._repository.list_active(self._resolved_locale_id())
         return MinistryListResult(items=items)
+
+    @distributed_trace()
+    async def get_steward_directory(self, command: StewardDirectoryQueryCommand) -> StewardDirectoryPageResult:
+        items, count = await self._repository.fetch_steward_directory(command, self._resolved_locale_id())
+        return StewardDirectoryPageResult(page=command.page, page_size=command.page_size, total=count, items=items)
 
     @distributed_trace()
     async def get_ministry_by_id(self, ministry_id: UUID, all_locales: bool = False) -> Optional[MinistryDetailResult]:
@@ -209,6 +222,7 @@ class MinistryService:
             dict(user_id=member.user_id, member_role=member.member_role.value, remark=member.remark, contact_email=member.contact_email)
             for member in command.members
         ]
+        self.validate_primary_and_secondary([MinistryMemberResult(user_id=member.user_id, member_role=member.member_role.value) for member in command.members])
         await self._repository.replace_members(ministry_id=ministry_id, members=member_rows)
 
     @distributed_trace()

--- a/portal/application/org/results.py
+++ b/portal/application/org/results.py
@@ -116,6 +116,8 @@ class MinistryListItemResult(UUIDBaseModel):
     is_active: bool = Field(default=True)
     ministry_type: Optional[MinistryTypeResult] = Field(default=None)
     target_audiences: list[TargetAudienceResult] = Field(default_factory=list)
+    created_at: Optional[datetime] = Field(default=None)
+    updated_at: Optional[datetime] = Field(default=None)
 
 
 class MinistryDetailResult(UUIDBaseModel):

--- a/portal/application/org/results.py
+++ b/portal/application/org/results.py
@@ -21,6 +21,7 @@ __all__ = [
     "MinistryListResult",
     "MinistryMemberResult",
     "MinistryPageResult",
+    "StewardDirectoryPageResult",
     "MinistryScheduleResult",
     "MinistryTypeResult",
     "MinistryTypeListResult",
@@ -160,6 +161,15 @@ class MinistryPageResult(BaseModel):
 class MinistryListResult(BaseModel):
     """Active ministries dropdown."""
 
+    items: list[MinistryListItemResult] = Field(default_factory=list)
+
+
+class StewardDirectoryPageResult(BaseModel):
+    """Paginated steward directory (ministry identity only)."""
+
+    page: int = Field(...)
+    page_size: int = Field(...)
+    total: int = Field(...)
     items: list[MinistryListItemResult] = Field(default_factory=list)
 
 

--- a/portal/application/org/steward_directory_query.py
+++ b/portal/application/org/steward_directory_query.py
@@ -1,0 +1,20 @@
+"""
+Steward directory q matching (Ministry name or Steward identity).
+"""
+
+from typing import Optional
+
+
+def matches_steward_directory_q(
+    q: Optional[str],
+    *,
+    translation_names: list[str],
+    steward_login_emails: list[Optional[str]],
+    steward_display_names: list[Optional[str]],
+    steward_contact_emails: list[Optional[str]],
+) -> bool:
+    needle = (q or "").strip().lower()
+    if not needle:
+        return True
+    values = [*translation_names, *steward_login_emails, *steward_display_names, *steward_contact_emails]
+    return any(needle in value.lower() for value in values if value)

--- a/portal/infrastructure/persistence/repositories/org/ministry_repository.py
+++ b/portal/infrastructure/persistence/repositories/org/ministry_repository.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 import ujson
 from asyncpg import UniqueViolationError
 
+from portal.application.org.commands import PagesQueryCommand, StewardDirectoryQueryCommand
 from portal.application.org.results import (
     MinistryApprovalResult,
     MinistryDetailResult,
@@ -19,7 +20,6 @@ from portal.application.org.results import (
     TargetAudienceResult,
     TranslationItemResult,
 )
-from portal.application.rbac.commands import PagesQueryCommand
 from portal.domain.org.constants import MinistryApprovalStatus, MinistryMemberRole, MinistryStatus
 from portal.infrastructure.persistence.repositories.shared.translation_queries import (
     default_locale_subquery,
@@ -214,6 +214,48 @@ class MinistryRepository:
             .fetch(as_model=MinistryListItemResult)
         )
         return items or []
+
+    def _steward_directory_q_exists(self, q: str):
+        pattern = f"%{q}%"
+        display_name = sa.func.coalesce(AuthUserProfile.preferred_name, AuthUser.email)
+        name_hit = sa.exists(
+            sa.select(1)
+            .select_from(OrgMinistryTranslation)
+            .where(OrgMinistryTranslation.ministry_id == OrgMinistry.id)
+            .where(OrgMinistryTranslation.name.ilike(pattern))
+        )
+        steward_hit = sa.exists(
+            sa.select(1)
+            .select_from(OrgMinistryMember)
+            .outerjoin(AuthUser, AuthUser.id == OrgMinistryMember.user_id)
+            .outerjoin(AuthUserProfile, AuthUserProfile.user_id == AuthUser.id)
+            .where(OrgMinistryMember.ministry_id == OrgMinistry.id)
+            .where(sa.or_(AuthUser.email.ilike(pattern), display_name.ilike(pattern), OrgMinistryMember.contact_email.ilike(pattern)))
+        )
+        return sa.or_(name_hit, steward_hit)
+
+    async def fetch_steward_directory(self, model: StewardDirectoryQueryCommand, locale_id: Optional[UUID]) -> tuple[list[MinistryListItemResult], int]:
+        query = self._session.select(
+            OrgMinistry.id, ministry_name_fallback(locale_id).label("name"), OrgMinistry.status, OrgMinistry.has_priority_booking, OrgMinistry.is_active
+        ).select_from(OrgMinistry)
+        if locale_id:
+            query = query.outerjoin(
+                OrgMinistryTranslation, sa.and_(OrgMinistryTranslation.ministry_id == OrgMinistry.id, OrgMinistryTranslation.locale_id == locale_id)
+            )
+        else:
+            query = query.outerjoin(OrgMinistryTranslation, sa.false())
+        query = query.where(OrgMinistry.is_deleted == False)
+        query = query.where(model.status is not None, lambda: OrgMinistry.status == model.status.value)
+        q = (model.q or "").strip()
+        query = query.where(bool(q), lambda: self._steward_directory_q_exists(q))
+        items, count = await (
+            query.group_by(OrgMinistry.id)
+            .order_by(OrgMinistry.sequence)
+            .limit(model.page_size)
+            .offset(model.page * model.page_size)
+            .fetchpages(no_order_by=False, as_model=MinistryListItemResult)
+        )
+        return items or [], count
 
     async def get_by_id(self, ministry_id: UUID, locale_id: Optional[UUID] = None, all_locales: bool = False) -> Optional[MinistryDetailResult]:
         row: Optional[MinistryDetailResult] = await (

--- a/portal/infrastructure/persistence/repositories/org/ministry_repository.py
+++ b/portal/infrastructure/persistence/repositories/org/ministry_repository.py
@@ -236,7 +236,13 @@ class MinistryRepository:
 
     async def fetch_steward_directory(self, model: StewardDirectoryQueryCommand, locale_id: Optional[UUID]) -> tuple[list[MinistryListItemResult], int]:
         query = self._session.select(
-            OrgMinistry.id, ministry_name_fallback(locale_id).label("name"), OrgMinistry.status, OrgMinistry.has_priority_booking, OrgMinistry.is_active
+            OrgMinistry.id,
+            ministry_name_fallback(locale_id).label("name"),
+            OrgMinistry.status,
+            OrgMinistry.has_priority_booking,
+            OrgMinistry.is_active,
+            OrgMinistry.created_at,
+            OrgMinistry.updated_at,
         ).select_from(OrgMinistry)
         if locale_id:
             query = query.outerjoin(
@@ -248,9 +254,12 @@ class MinistryRepository:
         query = query.where(model.status is not None, lambda: OrgMinistry.status == model.status.value)
         q = (model.q or "").strip()
         query = query.where(bool(q), lambda: self._steward_directory_q_exists(q))
+        order_by = model.order_by or "sequence"
         items, count = await (
             query.group_by(OrgMinistry.id)
-            .order_by(OrgMinistry.sequence)
+            .order_by_with(
+                tables=[OrgMinistry], order_by=order_by, descending=model.descending if model.order_by else False, name=sa.func.min(OrgMinistryTranslation.name)
+            )
             .limit(model.page_size)
             .offset(model.page * model.page_size)
             .fetchpages(no_order_by=False, as_model=MinistryListItemResult)
@@ -382,22 +391,19 @@ class MinistryRepository:
         await self._session.delete(OrgMinistryMember).where(OrgMinistryMember.ministry_id == ministry_id).execute()
         if not members:
             return
-        await (
-            self._session.insert(OrgMinistryMember)
-            .values(
-                [
-                    {
-                        "ministry_id": ministry_id,
-                        "user_id": member["user_id"],
-                        "member_role": member["member_role"],
-                        "remark": member.get("remark"),
-                        "contact_email": member.get("contact_email"),
-                    }
-                    for member in members
-                ]
-            )
-            .execute()
+        rows = apply_audit_fields_to_rows(
+            [
+                {
+                    "ministry_id": ministry_id,
+                    "user_id": member["user_id"],
+                    "member_role": member["member_role"],
+                    "remark": member.get("remark"),
+                    "contact_email": member.get("contact_email"),
+                }
+                for member in members
+            ]
         )
+        await self._session.insert(OrgMinistryMember).values(rows).execute()
 
     async def list_schedules(self, ministry_id: UUID) -> list[MinistryScheduleResult]:
         from portal.domain.facility.days_of_week_mask import mask_to_days

--- a/portal/routers/admin/v1/ministry/ministry.py
+++ b/portal/routers/admin/v1/ministry/ministry.py
@@ -21,6 +21,8 @@ from portal.application.org.mappers import (
     pages_query_to_command,
     reject_ministry_to_command,
     replace_ministry_members_to_command,
+    steward_directory_query_to_command,
+    steward_directory_to_api,
     update_ministry_to_command,
 )
 from portal.application.org.ministry_approval_service import MinistryApprovalService
@@ -37,7 +39,9 @@ from portal.serializers.admin.v1.ministry import (
     AdminMinistryPages,
     AdminMinistryReject,
     AdminMinistryReplaceMembers,
+    AdminMinistryStewardDirectoryPages,
     AdminMinistryUpdate,
+    AdminStewardDirectoryQuery,
 )
 from portal.serializers.mixins import DeleteBaseModel, DetailQueryModel, GenericQueryBaseModel
 from portal.serializers.mixins.model_mixins import UUIDBaseModel
@@ -59,6 +63,20 @@ async def get_ministry_pages(
 async def get_ministry_list(ministry_service: MinistryService = Depends(Provide[Container.org_ministry_service])):
     result = await ministry_service.get_ministry_list()
     return ministry_list_to_api(result)
+
+
+@router.get(
+    path="/steward-directory",
+    status_code=status.HTTP_200_OK,
+    response_model=AdminMinistryStewardDirectoryPages,
+    permissions=[Permission.MINISTRY_MINISTRY.read],
+)
+@inject
+async def get_steward_directory(
+    query_model: Annotated[AdminStewardDirectoryQuery, Query()], ministry_service: MinistryService = Depends(Provide[Container.org_ministry_service])
+):
+    result = await ministry_service.get_steward_directory(command=steward_directory_query_to_command(query_model))
+    return steward_directory_to_api(result)
 
 
 @router.post(path="", status_code=status.HTTP_201_CREATED, response_model=UUIDBaseModel, permissions=[Permission.MINISTRY_MINISTRY.create])

--- a/portal/serializers/admin/v1/ministry.py
+++ b/portal/serializers/admin/v1/ministry.py
@@ -9,10 +9,10 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 
 from portal.domain.facility.constants import DayOfWeek
-from portal.domain.org.constants import MinistryMemberRole
+from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 from portal.serializers.admin.v1.ministry_catalog import AdminMinistryTypeItem, AdminTargetAudienceItem
 from portal.serializers.admin.v1.org.translation import AdminOrgTranslationInput, AdminOrgTranslationItem, validate_unique_org_locale_ids
-from portal.serializers.mixins import PaginationBaseResponseModel
+from portal.serializers.mixins import PaginationBaseResponseModel, PaginationQueryBaseModel
 from portal.serializers.mixins.model_mixins import UUIDBaseModel
 
 
@@ -117,6 +117,19 @@ class AdminMinistryPages(PaginationBaseResponseModel):
 
 class AdminMinistryList(BaseModel):
     """Ministry dropdown list."""
+
+    items: list[AdminMinistryBase] = Field(default_factory=list, description="Items")
+
+
+class AdminStewardDirectoryQuery(PaginationQueryBaseModel):
+    """Steward directory query (snake_case)."""
+
+    q: Optional[str] = Field(None, description="Ministry name or steward identity")
+    status: Optional[MinistryStatus] = Field(None, description="Ministry status filter")
+
+
+class AdminMinistryStewardDirectoryPages(PaginationBaseResponseModel):
+    """Paginated steward directory."""
 
     items: list[AdminMinistryBase] = Field(default_factory=list, description="Items")
 

--- a/portal/serializers/admin/v1/ministry.py
+++ b/portal/serializers/admin/v1/ministry.py
@@ -12,7 +12,7 @@ from portal.domain.facility.constants import DayOfWeek
 from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 from portal.serializers.admin.v1.ministry_catalog import AdminMinistryTypeItem, AdminTargetAudienceItem
 from portal.serializers.admin.v1.org.translation import AdminOrgTranslationInput, AdminOrgTranslationItem, validate_unique_org_locale_ids
-from portal.serializers.mixins import PaginationBaseResponseModel, PaginationQueryBaseModel
+from portal.serializers.mixins import OrderByQueryBaseModel, PaginationBaseResponseModel
 from portal.serializers.mixins.model_mixins import UUIDBaseModel
 
 
@@ -83,6 +83,8 @@ class AdminMinistryBase(UUIDBaseModel):
     is_active: bool = Field(True, serialization_alias="isActive", description="Active flag")
     ministry_type: Optional[AdminMinistryTypeItem] = Field(None, serialization_alias="ministryType", description="Ministry type")
     target_audiences: list[AdminTargetAudienceItem] = Field(default_factory=list, serialization_alias="targetAudiences", description="Target audiences")
+    created_at: Optional[datetime] = Field(None, serialization_alias="createAt", description="Created at")
+    updated_at: Optional[datetime] = Field(None, serialization_alias="updateAt", description="Updated at")
 
 
 class AdminMinistryDetail(AdminMinistryBase):
@@ -98,9 +100,7 @@ class AdminMinistryDetail(AdminMinistryBase):
     rejected_at: Optional[datetime] = Field(None, serialization_alias="rejectedAt", description="Rejected at")
     rejected_by_id: Optional[UUID] = Field(None, serialization_alias="rejectedById", description="Rejected by")
     rejection_reason: Optional[str] = Field(None, serialization_alias="rejectionReason", description="Rejection reason")
-    created_at: Optional[datetime] = Field(None, serialization_alias="createAt", description="Created at")
     created_by: Optional[str] = Field(None, serialization_alias="createdBy", description="Created by")
-    updated_at: Optional[datetime] = Field(None, serialization_alias="updateAt", description="Updated at")
     updated_by: Optional[str] = Field(None, serialization_alias="updatedBy", description="Updated by")
     delete_reason: Optional[str] = Field(None, serialization_alias="deleteReason", description="Delete reason")
     translations: list[AdminOrgTranslationItem] = Field(default_factory=list, description="Translations")
@@ -121,7 +121,7 @@ class AdminMinistryList(BaseModel):
     items: list[AdminMinistryBase] = Field(default_factory=list, description="Items")
 
 
-class AdminStewardDirectoryQuery(PaginationQueryBaseModel):
+class AdminStewardDirectoryQuery(OrderByQueryBaseModel):
     """Steward directory query (snake_case)."""
 
     q: Optional[str] = Field(None, description="Ministry name or steward identity")

--- a/tests/application/org/test_ministry_services.py
+++ b/tests/application/org/test_ministry_services.py
@@ -3,7 +3,7 @@ Org application unit tests.
 """
 
 from datetime import time
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -13,19 +13,22 @@ from portal.application.org.commands import (
     MinistryMemberEntryCommand,
     MinistryScheduleCommand,
     OrgTranslationCommand,
+    PagesQueryCommand,
     ReplaceMinistryMembersCommand,
+    StewardDirectoryQueryCommand,
     SubmitMinistryCommand,
 )
 from portal.application.org.ministry_approval_service import MinistryApprovalService
 from portal.application.org.ministry_schedule import validate_ministry_schedules
 from portal.application.org.ministry_service import MinistryService
 from portal.application.org.results import MinistryDetailResult, MinistryMemberResult, TargetAudienceResult
+from portal.application.org.steward_directory_query import matches_steward_directory_q
 from portal.application.org.target_audience_validation import validate_target_audience_ids
 from portal.domain.facility.days_of_week_mask import days_to_mask, mask_to_days
 from portal.domain.org.catalog_codes import TARGET_AUDIENCE_ADULTS, TARGET_AUDIENCE_ALL_AGES
 from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 from portal.exceptions.responses import BadRequestException
-from tests.fixtures.org.stubs import StubMinistryRepository, StubMinistryTypeRepository, StubTargetAudienceRepository
+from tests.fixtures.org.stubs import StubMinistryRepository, StubMinistryTypeRepository, StubStewardDirectoryRow, StubTargetAudienceRepository
 
 
 def make_service(
@@ -150,3 +153,131 @@ def test_all_ages_target_audience_is_exclusive():
             [all_ages_id, adults_id],
             [TargetAudienceResult(id=all_ages_id, code=TARGET_AUDIENCE_ALL_AGES), TargetAudienceResult(id=adults_id, code=TARGET_AUDIENCE_ADULTS)],
         )
+
+
+def _directory_fixture() -> tuple[UUID, UUID, UUID, StubMinistryRepository]:
+    youth_id = uuid4()
+    alpha_id = uuid4()
+    empty_id = uuid4()
+    stub = StubMinistryRepository(
+        directory_rows=[
+            StubStewardDirectoryRow(
+                id=youth_id,
+                name="Youth",
+                status=MinistryStatus.DRAFT.value,
+                stewards=[{"email": "jane.login@example.com", "display_name": "Jane Steward", "contact_email": "jane.public@church.org"}],
+            ),
+            StubStewardDirectoryRow(id=alpha_id, name="Alpha 2026", status=MinistryStatus.ACTIVE.value, stewards=[]),
+            StubStewardDirectoryRow(id=empty_id, name="Choir", status=MinistryStatus.INACTIVE.value, stewards=[]),
+            StubStewardDirectoryRow(
+                id=uuid4(),
+                name="Deleted Group",
+                status=MinistryStatus.ACTIVE.value,
+                is_deleted=True,
+                stewards=[{"email": "gone@example.com", "display_name": "Gone", "contact_email": None}],
+            ),
+        ]
+    )
+    return youth_id, alpha_id, empty_id, stub
+
+
+def test_matches_steward_directory_q_is_case_insensitive_partial():
+    assert matches_steward_directory_q(
+        "JANE",
+        translation_names=["Youth"],
+        steward_login_emails=["jane.login@example.com"],
+        steward_display_names=["Jane Steward"],
+        steward_contact_emails=["jane.public@church.org"],
+    )
+    assert matches_steward_directory_q(
+        "login",
+        translation_names=["Youth"],
+        steward_login_emails=["jane.login@example.com"],
+        steward_display_names=["Jane Steward"],
+        steward_contact_emails=["jane.public@church.org"],
+    )
+    assert matches_steward_directory_q(
+        "church.org",
+        translation_names=["Youth"],
+        steward_login_emails=["jane.login@example.com"],
+        steward_display_names=["Jane Steward"],
+        steward_contact_emails=["jane.public@church.org"],
+    )
+    assert not matches_steward_directory_q("Jane", translation_names=["Choir"], steward_login_emails=[], steward_display_names=[], steward_contact_emails=[])
+
+
+@pytest.mark.asyncio
+async def test_steward_directory_empty_q_includes_empty_rosters_and_omits_deleted():
+    youth_id, alpha_id, empty_id, stub = _directory_fixture()
+    result = await make_service(stub).get_steward_directory(StewardDirectoryQueryCommand())
+    ids = {item.id for item in result.items}
+    assert ids == {youth_id, alpha_id, empty_id}
+    assert result.total == 3
+    assert all("members" not in item.model_dump() for item in result.items)
+
+
+@pytest.mark.asyncio
+async def test_steward_directory_filters_status():
+    _, alpha_id, _, stub = _directory_fixture()
+    result = await make_service(stub).get_steward_directory(StewardDirectoryQueryCommand(status=MinistryStatus.ACTIVE))
+    assert [item.id for item in result.items] == [alpha_id]
+
+
+@pytest.mark.asyncio
+async def test_steward_directory_q_matches_ministry_name_and_steward_identity():
+    youth_id, alpha_id, _, stub = _directory_fixture()
+    service = make_service(stub)
+    by_name = await service.get_steward_directory(StewardDirectoryQueryCommand(q="alpha"))
+    assert [item.id for item in by_name.items] == [alpha_id]
+    by_person = await service.get_steward_directory(StewardDirectoryQueryCommand(q="Jane"))
+    assert [item.id for item in by_person.items] == [youth_id]
+    mixed = await service.get_steward_directory(StewardDirectoryQueryCommand(q="a"))
+    assert {item.id for item in mixed.items} == {youth_id, alpha_id}
+
+
+@pytest.mark.asyncio
+async def test_steward_directory_person_q_excludes_empty_roster():
+    youth_id, _, empty_id, stub = _directory_fixture()
+    service = make_service(stub)
+    by_name = await service.get_steward_directory(StewardDirectoryQueryCommand(q="Choir"))
+    assert [item.id for item in by_name.items] == [empty_id]
+    by_person = await service.get_steward_directory(StewardDirectoryQueryCommand(q="Jane"))
+    assert [item.id for item in by_person.items] == [youth_id]
+    person_miss = await service.get_steward_directory(StewardDirectoryQueryCommand(q="Nobody"))
+    assert person_miss.items == []
+
+
+@pytest.mark.asyncio
+async def test_steward_directory_paginates():
+    _, _, _, stub = _directory_fixture()
+    result = await make_service(stub).get_steward_directory(StewardDirectoryQueryCommand(page=0, page_size=1))
+    assert result.page == 0
+    assert result.page_size == 1
+    assert result.total == 3
+    assert len(result.items) == 1
+
+
+@pytest.mark.asyncio
+async def test_ministry_pages_keyword_matches_name_not_steward():
+    youth_id, _, _, stub = _directory_fixture()
+    service = make_service(stub)
+    by_name = await service.get_ministry_pages(PagesQueryCommand(keyword="Youth"))
+    assert [item.id for item in by_name.items] == [youth_id]
+    by_steward = await service.get_ministry_pages(PagesQueryCommand(keyword="Jane"))
+    assert by_steward.items == []
+
+
+@pytest.mark.asyncio
+async def test_replace_members_rejects_missing_secondary():
+    ministry_id = uuid4()
+    stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(id=ministry_id, name="Youth", status=MinistryStatus.DRAFT.value, has_priority_booking=False, is_active=True)
+        }
+    )
+    service = make_service(stub)
+    with pytest.raises(BadRequestException, match="secondary"):
+        await service.replace_members(
+            ministry_id, ReplaceMinistryMembersCommand(members=[MinistryMemberEntryCommand(user_id=uuid4(), member_role=MinistryMemberRole.PRIMARY)])
+        )
+    assert stub.replace_members_calls == []

--- a/tests/application/org/test_ministry_services.py
+++ b/tests/application/org/test_ministry_services.py
@@ -258,6 +258,13 @@ async def test_steward_directory_paginates():
 
 
 @pytest.mark.asyncio
+async def test_steward_directory_orders_by_name():
+    youth_id, alpha_id, empty_id, stub = _directory_fixture()
+    result = await make_service(stub).get_steward_directory(StewardDirectoryQueryCommand(order_by="name", descending=False, page_size=10))
+    assert [item.id for item in result.items] == [alpha_id, empty_id, youth_id]
+
+
+@pytest.mark.asyncio
 async def test_ministry_pages_keyword_matches_name_not_steward():
     youth_id, _, _, stub = _directory_fixture()
     service = make_service(stub)

--- a/tests/fixtures/org/stubs.py
+++ b/tests/fixtures/org/stubs.py
@@ -2,10 +2,11 @@
 Stub repositories for org application unit tests.
 """
 
+from dataclasses import dataclass, field
 from typing import Optional
 from uuid import UUID
 
-from portal.application.org.commands import PagesQueryCommand
+from portal.application.org.commands import PagesQueryCommand, StewardDirectoryQueryCommand
 from portal.application.org.results import (
     MinistryApprovalResult,
     MinistryDetailResult,
@@ -14,7 +15,27 @@ from portal.application.org.results import (
     MinistryTypeResult,
     TargetAudienceResult,
 )
+from portal.application.org.steward_directory_query import matches_steward_directory_q
 from portal.domain.org.catalog_codes import MINISTRY_TYPE_INTERNAL
+from portal.domain.org.constants import MinistryStatus
+
+
+@dataclass
+class StubStewardDirectoryRow:
+    """In-memory ministry row for steward directory and pages keyword tests."""
+
+    id: UUID
+    name: str
+    status: str = MinistryStatus.ACTIVE.value
+    is_deleted: bool = False
+    is_active: bool = True
+    has_priority_booking: bool = False
+    translation_names: list[str] = field(default_factory=list)
+    stewards: list[dict[str, Optional[str]]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.translation_names:
+            self.translation_names = [self.name]
 
 
 class StubMinistryTypeRepository:
@@ -55,10 +76,14 @@ class StubMinistryRepository:
     """In-memory org ministry stub."""
 
     def __init__(
-        self, ministry_by_id: dict[UUID, MinistryDetailResult] | None = None, members_by_ministry: dict[UUID, list[MinistryMemberResult]] | None = None
+        self,
+        ministry_by_id: dict[UUID, MinistryDetailResult] | None = None,
+        members_by_ministry: dict[UUID, list[MinistryMemberResult]] | None = None,
+        directory_rows: list[StubStewardDirectoryRow] | None = None,
     ):
         self.ministry_by_id = ministry_by_id or {}
         self.members_by_ministry = members_by_ministry or {}
+        self.directory_rows = directory_rows or []
         self.insert_calls: list[dict] = []
         self.update_calls: list[dict] = []
         self.upsert_translation_calls: list[list] = []
@@ -109,7 +134,41 @@ class StubMinistryRepository:
         self.update_approval_calls.append(kwargs)
 
     async def fetch_pages(self, command: PagesQueryCommand, locale_id):
-        return [], 0
+        items: list[MinistryDetailResult] = []
+        needle = (command.keyword or "").strip().lower()
+        for row in self.directory_rows:
+            if row.is_deleted != command.deleted:
+                continue
+            names = row.translation_names or [row.name]
+            if needle and not any(needle in name.lower() for name in names if name):
+                continue
+            items.append(
+                MinistryDetailResult(id=row.id, name=row.name, status=row.status, has_priority_booking=row.has_priority_booking, is_active=row.is_active)
+            )
+        return items, len(items)
+
+    async def fetch_steward_directory(self, command: StewardDirectoryQueryCommand, locale_id):
+        items: list[MinistryListItemResult] = []
+        for row in self.directory_rows:
+            if row.is_deleted:
+                continue
+            if command.status and row.status != command.status.value:
+                continue
+            stewards = row.stewards or []
+            if not matches_steward_directory_q(
+                command.q,
+                translation_names=row.translation_names or [row.name],
+                steward_login_emails=[item.get("email") for item in stewards],
+                steward_display_names=[item.get("display_name") for item in stewards],
+                steward_contact_emails=[item.get("contact_email") for item in stewards],
+            ):
+                continue
+            items.append(
+                MinistryListItemResult(id=row.id, name=row.name, status=row.status, has_priority_booking=row.has_priority_booking, is_active=row.is_active)
+            )
+        total = len(items)
+        start = command.page * command.page_size
+        return items[start : start + command.page_size], total
 
     async def list_active(self, locale_id) -> list[MinistryListItemResult]:
         return []

--- a/tests/fixtures/org/stubs.py
+++ b/tests/fixtures/org/stubs.py
@@ -32,6 +32,9 @@ class StubStewardDirectoryRow:
     has_priority_booking: bool = False
     translation_names: list[str] = field(default_factory=list)
     stewards: list[dict[str, Optional[str]]] = field(default_factory=list)
+    sequence: float = 0.0
+    created_at: Optional[object] = None
+    updated_at: Optional[object] = None
 
     def __post_init__(self) -> None:
         if not self.translation_names:
@@ -164,8 +167,33 @@ class StubMinistryRepository:
             ):
                 continue
             items.append(
-                MinistryListItemResult(id=row.id, name=row.name, status=row.status, has_priority_booking=row.has_priority_booking, is_active=row.is_active)
+                MinistryListItemResult(
+                    id=row.id,
+                    name=row.name,
+                    status=row.status,
+                    has_priority_booking=row.has_priority_booking,
+                    is_active=row.is_active,
+                    created_at=row.created_at,
+                    updated_at=row.updated_at,
+                )
             )
+
+        order_by = command.order_by or "sequence"
+        reverse = command.descending if command.order_by else False
+
+        def sort_key(item: MinistryListItemResult):
+            if order_by == "name":
+                return (item.name or "").lower()
+            if order_by == "updated_at":
+                return item.updated_at or ""
+            if order_by == "created_at":
+                return item.created_at or ""
+            if order_by == "status":
+                return item.status
+            row = next((entry for entry in self.directory_rows if entry.id == item.id), None)
+            return row.sequence if row else 0.0
+
+        items.sort(key=sort_key, reverse=reverse)
         total = len(items)
         start = command.page * command.page_size
         return items[start : start + command.page_size], total


### PR DESCRIPTION
## Summary

Adds a dedicated admin steward-directory read for finding ministries by name or steward identity, without embedding roster data on list/pages. Also returns create/update timestamps, supports `order_by`/`descending`, and fixes `created_by` audit fields when replacing ministry members.

Closes #65

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- New `GET /admin/api/v1/ministry/ministries/steward-directory` (paginated ministries only; roster stays on detail).
- ADR `docs/adr/0004-steward-directory-query.md` documents why this is not generic pages `keyword`.
- `replace_members` bulk insert now uses `apply_audit_fields_to_rows` to satisfy NOT NULL audit columns.

## Testing

- [x] `uv run pytest tests/application/org/test_ministry_services.py -q`
- [x] `uv run ruff format` / `uv run ruff check --fix` on touched files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge