### PR TITLE
feat: add facilityIds to admin booking list items

### DIFF
--- a/portal/application/facility/results.py
+++ b/portal/application/facility/results.py
@@ -335,6 +335,7 @@ class BookingListItemResult(UUIDBaseModel):
     user_display_name: Optional[str] = Field(default=None)
     facility_id: Optional[UUID] = Field(default=None)
     facility_name: Optional[str] = Field(default=None)
+    facility_ids: list[UUID] = Field(default_factory=list)
     facility_names: list[str] = Field(default_factory=list)
     booking_type: str = Field(...)
     start_at: datetime = Field(...)

--- a/portal/infrastructure/persistence/repositories/facility/booking_repository.py
+++ b/portal/infrastructure/persistence/repositories/facility/booking_repository.py
@@ -118,16 +118,37 @@ class BookingRepository:
         )
         items = items or []
         if items:
-            names_by_booking_id = await self._fetch_facility_names_by_booking_ids([item.id for item in items], locale_id)
+            ids_by_booking_id, names_by_booking_id = await self._fetch_facility_lines_by_booking_ids([item.id for item in items], locale_id)
             items = [
-                item.model_copy(update={"facility_names": names_by_booking_id.get(item.id) or ([item.facility_name] if item.facility_name else [])})
+                item.model_copy(
+                    update={
+                        "facility_ids": ids_by_booking_id.get(item.id) or [],
+                        "facility_names": names_by_booking_id.get(item.id) or ([item.facility_name] if item.facility_name else []),
+                    }
+                )
                 for item in items
             ]
         return items, count
 
-    async def _fetch_facility_names_by_booking_ids(self, booking_ids: list[UUID], locale_id: Optional[UUID]) -> dict[UUID, list[str]]:
+    @staticmethod
+    def group_facility_lines(rows: list[dict[str, Any]]) -> tuple[dict[UUID, list[UUID]], dict[UUID, list[str]]]:
+        """Group room-line rows into ordered facility ids and display names per booking."""
+        ids_by_booking_id: dict[UUID, list[UUID]] = {}
+        names_by_booking_id: dict[UUID, list[str]] = {}
+        for row in rows:
+            booking_id = row["facility_booking_id"]
+            facility_id = row["facility_id"]
+            ids_by_booking_id.setdefault(booking_id, []).append(facility_id)
+            name = row["facility_name"]
+            if name:
+                names_by_booking_id.setdefault(booking_id, []).append(str(name))
+        return ids_by_booking_id, names_by_booking_id
+
+    async def _fetch_facility_lines_by_booking_ids(
+        self, booking_ids: list[UUID], locale_id: Optional[UUID]
+    ) -> tuple[dict[UUID, list[UUID]], dict[UUID, list[str]]]:
         if not booking_ids:
-            return {}
+            return {}, {}
         room_name = FacilityRoom.code
         if locale_id:
             room_name = sa.func.coalesce(
@@ -138,20 +159,14 @@ class BookingRepository:
                 FacilityRoom.code,
             )
         rows = await (
-            self._session.select(FacilityBookingRoom.facility_booking_id, room_name.label("facility_name"))
+            self._session.select(FacilityBookingRoom.facility_booking_id, FacilityBookingRoom.facility_id, room_name.label("facility_name"))
             .select_from(FacilityBookingRoom)
             .join(FacilityRoom, FacilityRoom.id == FacilityBookingRoom.facility_id)
             .where(FacilityBookingRoom.facility_booking_id.in_(booking_ids))
             .order_by(FacilityBookingRoom.facility_booking_id.asc(), FacilityBookingRoom.sequence.asc())
             .fetch()
         )
-        result: dict[UUID, list[str]] = {}
-        for row in rows or []:
-            booking_id = row["facility_booking_id"]
-            name = row["facility_name"]
-            if name:
-                result.setdefault(booking_id, []).append(str(name))
-        return result
+        return self.group_facility_lines(list(rows or []))
 
     async def get_detail(self, booking_id: UUID, locale_id: Optional[UUID]) -> Optional[BookingDetailResult]:
         row = await (

--- a/portal/serializers/admin/v1/facility/booking.py
+++ b/portal/serializers/admin/v1/facility/booking.py
@@ -60,6 +60,7 @@ class AdminBookingListItem(UUIDBaseModel):
     user_display_name: Optional[str] = Field(default=None, serialization_alias="userDisplayName")
     facility_id: Optional[UUID] = Field(default=None, serialization_alias="facilityId")
     facility_name: Optional[str] = Field(default=None, serialization_alias="facilityName")
+    facility_ids: list[UUID] = Field(default_factory=list, serialization_alias="facilityIds")
     facility_names: list[str] = Field(default_factory=list, serialization_alias="facilityNames")
     booking_type: str = Field(..., serialization_alias="bookingType")
     start_at: datetime = Field(..., serialization_alias="startAt")

--- a/tests/application/facility/test_mappers.py
+++ b/tests/application/facility/test_mappers.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from uuid import uuid4
 
 from portal.application.facility.mappers import (
+    booking_page_to_api,
     booking_pages_query_to_command,
     bulk_action_to_command,
     cancel_booking_to_command,
@@ -25,11 +26,20 @@ from portal.application.facility.mappers import (
     update_booking_to_command,
     update_policy_setting_to_command,
 )
-from portal.application.facility.results import DiscountRuleResult, PreviewQuoteResult, PreviewQuoteRoomLineResult, RoomDetailResult, TranslationItemResult
+from portal.application.facility.results import (
+    BookingListItemResult,
+    BookingPageResult,
+    DiscountRuleResult,
+    PreviewQuoteResult,
+    PreviewQuoteRoomLineResult,
+    RoomDetailResult,
+    TranslationItemResult,
+)
 from portal.application.org.mappers import create_ministry_to_command, ministry_detail_to_api, replace_ministry_members_to_command
 from portal.application.org.results import MinistryDetailResult
 from portal.domain.facility.constants import BookingType, RentalRateBillingUnit
 from portal.domain.org.constants import MinistryMemberRole
+from portal.infrastructure.persistence.repositories.facility.booking_repository import BookingRepository
 from portal.serializers.admin.v1.facility.booking import AdminBookingCancel, AdminBookingQuery, AdminBookingUpdate
 from portal.serializers.admin.v1.facility.override_log import AdminOverrideLogQuery
 from portal.serializers.admin.v1.facility.rental_catalog import AdminDiscountRuleCreate, AdminPolicySettingUpdate, AdminSurchargeCreate
@@ -226,6 +236,68 @@ def test_booking_and_member_mappers():
     cancel_cmd = cancel_booking_to_command(AdminBookingCancel(scope="series", cancel_reason="weather"))
     assert cancel_cmd.scope == "series"
     assert cancel_cmd.cancel_reason == "weather"
+
+
+def test_booking_page_to_api_includes_ordered_facility_ids():
+    primary_id = uuid4()
+    secondary_id = uuid4()
+    start = datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    item = BookingListItemResult(
+        id=uuid4(),
+        user_id=uuid4(),
+        facility_id=primary_id,
+        facility_ids=[primary_id, secondary_id],
+        facility_names=["Gym", "Hall"],
+        booking_type="one_time",
+        start_at=start,
+        end_at=end,
+        status="confirmed",
+    )
+    api = booking_page_to_api(BookingPageResult(page=0, page_size=20, total=1, items=[item]))
+    assert api.items[0].facility_id == primary_id
+    assert api.items[0].facility_ids == [primary_id, secondary_id]
+    assert api.items[0].model_dump(by_alias=True)["facilityIds"] == [primary_id, secondary_id]
+
+
+def test_booking_page_to_api_keeps_empty_facility_ids_and_primary():
+    primary_id = uuid4()
+    start = datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    item = BookingListItemResult(
+        id=uuid4(),
+        user_id=uuid4(),
+        facility_id=primary_id,
+        facility_ids=[],
+        facility_names=[],
+        booking_type="one_time",
+        start_at=start,
+        end_at=end,
+        status="confirmed",
+    )
+    api = booking_page_to_api(BookingPageResult(page=0, page_size=20, total=1, items=[item]))
+    assert api.items[0].facility_id == primary_id
+    assert api.items[0].facility_ids == []
+
+
+def test_group_facility_lines_preserves_room_line_order():
+    booking_a = uuid4()
+    booking_b = uuid4()
+    room_1 = uuid4()
+    room_2 = uuid4()
+    room_3 = uuid4()
+    ids_by_booking, names_by_booking = BookingRepository.group_facility_lines(
+        [
+            {"facility_booking_id": booking_a, "facility_id": room_2, "facility_name": "B"},
+            {"facility_booking_id": booking_a, "facility_id": room_1, "facility_name": "A"},
+            {"facility_booking_id": booking_b, "facility_id": room_3, "facility_name": "C"},
+            {"facility_booking_id": booking_b, "facility_id": room_3, "facility_name": None},
+        ]
+    )
+    assert ids_by_booking[booking_a] == [room_2, room_1]
+    assert names_by_booking[booking_a] == ["B", "A"]
+    assert ids_by_booking[booking_b] == [room_3, room_3]
+    assert names_by_booking[booking_b] == ["C"]
 
 
 def test_override_log_pages_query_to_command():


### PR DESCRIPTION
## Summary

Adds ordered `facilityIds` on admin booking list items (alongside existing Primary `facilityId` / `facilityNames`) so Booking Grid can place multi-room occupancy without guessing from display names.

Closes #64

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Enrichment runs in the same room-line pass as `facility_names`, ordered by sequence.
- Empty room lines → `facilityIds: []`; Primary `facility_id` unchanged.
- Member `/api/v1` list mapper still omits the field; shared result type may carry it server-side.

## Testing

- [x] `uv run pytest`
- [x] `uv run ruff format` / `uv run ruff check --fix` on touched files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)