### PR TITLE
chore: enforce Ruff on staged files via .githooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Format staged Python files (Ruff) before commit; re-stage results.
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel </dev/null)"
+exec "${ROOT_DIR}/scripts/format-staged.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ uv run uvicorn portal.main:app --reload
 uv run pytest
 uv run pytest tests/application/rbac/test_permission_service.py -v
 ./scripts/check-branch-name.test.sh
+./scripts/format-staged.test.sh
 
 # Format (layout, then import sort — I only)
 uv run ruff format
@@ -65,6 +66,10 @@ uv run ruff check --fix
 ### Branch names
 
 Topic branches: `{type}/{issue-number}-{short-description}` (types: `feat` `fix` `hotfix` `refactor` `perf` `test` `docs` `chore` `build` `ci`). Exceptions: `release/x.y.z`, `spike/{short-description}`, plus `main` / `develop`. Enforced by `.githooks/pre-push` (after install) and `.github/workflows/branch-name.yml` on PRs. Emergency local bypass: `git push --no-verify`. Consider marking the `Branch name` check required in GitHub branch protection.
+
+### Commit format hook
+
+After `./scripts/install-git-hooks.sh`, `.githooks/pre-commit` formats **staged** `*.py` via `scripts/format-staged.sh` (Ruff format + I-only `--fix`) and re-stages. Emergency: `git commit --no-verify`. See ADR 0006.
 
 Python layout is Ruff, not PyCharm Reformat. Disable PyCharm's built-in Python formatter, or use a Ruff plugin that reads `[tool.ruff]`. EditorConfig `ij_python_*` wrap/align keys are not the contract.
 
@@ -428,6 +433,7 @@ Use **Permission** or **Verb** as the reference implementation.
 | `.cursor/rules/standard.mdc`                                              | Full coding standards (ORM examples, repository patterns) |
 | `pyproject.toml`                                                          | uv + Ruff contract (`[tool.ruff]`)                        |
 | `docs/adr/0003-ruff-is-the-formatter.md`                                  | Why Ruff, I-only lint select, not Black                   |
+| `docs/adr/0006-githooks-enforce-ruff-on-commit.md`                        | `.githooks` pre-commit runs Ruff on staged files          |
 | `portal/apps.py`                                                          | App mounting, middleware, exception handlers              |
 | `portal/container.py`                                                     | All wired services                                        |
 | `portal/routers/admin/v1/permission.py`                                   | Canonical router pattern                                  |

--- a/docs/adr/0006-githooks-enforce-ruff-on-commit.md
+++ b/docs/adr/0006-githooks-enforce-ruff-on-commit.md
@@ -1,0 +1,15 @@
+# .githooks enforce Ruff on commit
+
+Ruff remains the Python formatter (ADR 0003). Commit-time enforcement uses this repo's `.githooks` directory via `core.hooksPath` (same install story as branch-name `pre-push`), not the Python `pre-commit` framework and not Husky. `.githooks/pre-commit` calls `scripts/format-staged.sh`, which runs `uv run ruff format` and `uv run ruff check --fix` (I-only) on staged `*.py` files and re-stages them.
+
+## Considered Options
+
+- **Python `pre-commit` package** — common, but a second hook installer beside `core.hooksPath=.githooks` for branch checks.
+- **Husky / lint-staged** — Node-centric; wrong stack for this repo and conflicts with the org `.githooks` convention.
+- **Document-only Ruff** — already failed to keep style consistent across editors and agents.
+
+## Consequences
+
+- Clone once: `./scripts/install-git-hooks.sh`.
+- Emergency bypass: `git commit --no-verify` (local only).
+- Do not broaden Ruff lint select beyond `I` in the hook.

--- a/scripts/format-staged.sh
+++ b/scripts/format-staged.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Format and lint-fix staged Python files, then re-stage them.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+mapfile -t staged_files < <(
+  git diff --cached --name-only --diff-filter=ACMR -- '*.py' \
+    | while IFS= read -r path; do
+        [[ -f "${path}" ]] && printf '%s\n' "${path}"
+      done
+)
+
+if [[ "${#staged_files[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+uv run ruff format --force-exclude -- "${staged_files[@]}"
+uv run ruff check --fix --force-exclude --select I -- "${staged_files[@]}"
+git add -- "${staged_files[@]}"

--- a/scripts/format-staged.test.sh
+++ b/scripts/format-staged.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Black-box tests for scripts/format-staged.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMATTER="${ROOT_DIR}/scripts/format-staged.sh"
+FIXTURE_DIR="${ROOT_DIR}/scripts/.format-staged-fixtures"
+pass_count=0
+fail_count=0
+
+cleanup() {
+  if [[ -d "${FIXTURE_DIR}" ]]; then
+    git -C "${ROOT_DIR}" reset HEAD -- "${FIXTURE_DIR}" >/dev/null 2>&1 || true
+    rm -rf "${FIXTURE_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${FIXTURE_DIR}"
+
+assert_true() {
+  local label="$1"
+  shift
+  if "$@"; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${label}"
+  fi
+}
+
+is_staged() {
+  local rel="$1"
+  git -C "${ROOT_DIR}" diff --cached --name-only -- "${rel}" | grep -qx "${rel}"
+}
+
+# --- formats and re-stages an ugly Python file ---
+rel_ugly="scripts/.format-staged-fixtures/ugly_format.py"
+ugly_file="${ROOT_DIR}/${rel_ugly}"
+cat >"${ugly_file}" <<'PY'
+def hello(  ):
+    return   "world"
+PY
+git -C "${ROOT_DIR}" add -- "${rel_ugly}"
+
+set +e
+out="$("${FORMATTER}" 2>&1)"
+status=$?
+set -e
+
+assert_true "format-staged exits 0 for formatable Python" test "${status}" -eq 0
+assert_true "formatted file keeps double-quoted string" grep -q 'return "world"' "${ugly_file}"
+assert_true "formatted file removes extra spaces in def" grep -q 'def hello():' "${ugly_file}"
+assert_true "formatted file is still staged" is_staged "${rel_ugly}"
+assert_true "working tree matches index for fixture" git -C "${ROOT_DIR}" diff --quiet -- "${rel_ugly}"
+
+git -C "${ROOT_DIR}" reset HEAD -- "${rel_ugly}" >/dev/null
+rm -f "${ugly_file}"
+
+# --- fixes import order (I) and re-stages ---
+rel_imports="scripts/.format-staged-fixtures/ugly_imports.py"
+imports_file="${ROOT_DIR}/${rel_imports}"
+cat >"${imports_file}" <<'PY'
+import os
+import sys
+
+from portal.libs.tracing.distributed_trace import distributed_trace
+import json
+PY
+git -C "${ROOT_DIR}" add -- "${rel_imports}"
+
+set +e
+out="$("${FORMATTER}" 2>&1)"
+status=$?
+set -e
+
+assert_true "format-staged exits 0 when fixing imports" test "${status}" -eq 0
+assert_true "import json is among stdlib imports" grep -q '^import json$' "${imports_file}"
+assert_true "portal import remains" grep -q 'from portal.libs.tracing.distributed_trace import distributed_trace' "${imports_file}"
+assert_true "imports file still staged" is_staged "${rel_imports}"
+
+git -C "${ROOT_DIR}" reset HEAD -- "${rel_imports}" >/dev/null
+rm -f "${imports_file}"
+
+# --- no staged Python files: exit 0 ---
+rel_txt="scripts/.format-staged-fixtures/note.txt"
+non_py="${ROOT_DIR}/${rel_txt}"
+echo "hello" >"${non_py}"
+git -C "${ROOT_DIR}" add -- "${rel_txt}"
+set +e
+out="$("${FORMATTER}" 2>&1)"
+status=$?
+set -e
+assert_true "format-staged exits 0 when no staged Python" test "${status}" -eq 0
+git -C "${ROOT_DIR}" reset HEAD -- "${rel_txt}" >/dev/null
+rm -f "${non_py}"
+
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "${fail_count} failed, ${pass_count} passed"
+  echo "${out:-}"
+  exit 1
+fi
+
+echo "All ${pass_count} checks passed"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -6,7 +6,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/check-branch-name.sh scripts/check-branch-name.test.sh scripts/install-git-hooks.sh
+chmod +x \
+  .githooks/pre-push \
+  .githooks/pre-commit \
+  scripts/check-branch-name.sh \
+  scripts/check-branch-name.test.sh \
+  scripts/format-staged.sh \
+  scripts/format-staged.test.sh \
+  scripts/install-git-hooks.sh
 
 echo "Installed git hooks (core.hooksPath=.githooks)"
-echo "Emergency bypass: git push --no-verify"
+echo "Emergency bypass: git commit --no-verify / git push --no-verify"


### PR DESCRIPTION
## Summary

Add a `.githooks` `pre-commit` path that formats and import-sorts **staged** Python files with Ruff (ADR 0003 contract), re-stages results, and documents install via `scripts/install-git-hooks.sh`. Matches the org `.githooks` / `core.hooksPath` convention (no Husky, no Python `pre-commit` package).

Closes #71

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [x] Dependency or tooling

## Implementation notes

- Seam: `scripts/format-staged.sh` (+ shell black-box tests)
- Ruff uses `--force-exclude` so `alembic/versions` stays excluded when paths are passed explicitly
- ADR 0006 records `.githooks` as the enforcement entry

## Testing

- [x] `./scripts/format-staged.test.sh`
- [x] `./scripts/check-branch-name.test.sh` (unchanged; still present)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)