### PR TITLE
feat: add booking range query for Calendar and Grid

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,8 +19,12 @@ The booking's main room id used for list filters (`facility_id` / list `facility
 _Avoid_: room (ambiguous when multiple), main room (synonym drift), treating Primary facility as the only room shown on Booking Grid
 
 **Booking view mode**:
-How the admin booking management page presents bookings: `list`, `calendar`, or `grid`. Default is `list`. v1 syncs `view` and an ISO `date` (calendar/grid anchor day) into the page URL query; list may ignore `date`. Calendar week-vs-day is UI state only, not part of the URL. Calendar is the time overview of bookings: overlapping bookings are distinct clickable blocks in side-by-side lanes, up to a density cap; beyond that, occupancy is read on Grid. Grid is the single-day room-row occupancy view: a multi-room booking appears on every occupied room row. List is the paginated record set.
-_Avoid_: tab (UI chrome only), layout, perspective, treating Calendar and Grid as interchangeable concurrent-booking surfaces, summarizing concurrent Calendar bookings into one representative block
+How the admin booking management page presents bookings: `list`, `calendar`, or `grid`. Default is `list`. v1 syncs `view` and an ISO `date` (calendar/grid anchor day) into the page URL query; list may ignore `date`. Calendar week-vs-day is UI state only, not part of the URL. Calendar is the time overview of bookings: overlapping bookings are distinct clickable blocks in side-by-side lanes, up to a density cap; beyond that, occupancy is read on Grid. Grid is the single-day room-row occupancy view: a multi-room booking appears on every occupied room row. List is the paginated record set. Calendar and Grid load bookings via a Booking range query for the visible window, not via List pagination.
+_Avoid_: tab (UI chrome only), layout, perspective, treating Calendar and Grid as interchangeable concurrent-booking surfaces, summarizing concurrent Calendar bookings into one representative block, using paginated List pages as the Calendar/Grid completeness contract
+
+**Booking range query**:
+A non-paginated admin read: every booking whose interval overlaps a required time window. Used by Calendar and Booking Grid so the visible window is complete. Matching is interval overlap, not `start_at`-in-window. Cancelled bookings are omitted by default and may be requested via an explicit flag. The allowed window length is capped. Distinct from the paginated List `pages` query.
+_Avoid_: List `pages` with a large page size, silent truncation as acceptable Calendar/Grid behavior, `start_at`-only window filters for occupancy views
 
 **Scheduling Conflict**:
 A booking create or update rejected because a requested room interval overlaps a confirmed booking slot. Distinct from uniqueness conflicts (duplicate codes) and from Blackout overlap.

--- a/docs/adr/0007-booking-range-query.md
+++ b/docs/adr/0007-booking-range-query.md
@@ -1,0 +1,26 @@
+# 0007. Booking range query for Calendar and Grid
+
+## Status
+
+Accepted
+
+## Context
+
+Admin List correctly uses paginated `GET .../booking/pages`. Calendar and Booking Grid were loading the visible window through that same endpoint with `page=0` and a large `page_size`, which silently truncates busy windows and teaches the wrong contract. The pages date filter also matched `start_at` inside the window, not interval overlap, so bookings that span the window edge could be missing from occupancy views. Month Calendar layout (portal ADR 0006) widens the typical window and makes truncation more likely.
+
+## Decision
+
+Introduce a dedicated non-paginated **Booking range query** for Calendar and Booking Grid. List keeps `pages`.
+
+- Required `date_from` / `date_to` (or equivalent). Return every non-deleted booking whose interval **overlaps** the window: `start < window_end` and `end > window_start` (half-open-friendly overlap, consistent with Calendar collision rules).
+- Cancelled bookings are **excluded by default** and may be included via an explicit query flag.
+- Cap the allowed window length (about 62 days — enough for a visible month grid, not an unbounded dump). Oversized windows are rejected.
+- Response is a complete list for that window (list-item-shaped rows sufficient for Calendar/Grid), with no `page` / `page_size` completeness semantics.
+- Portal Calendar and Grid both switch to this query; do not keep `pages` + large `page_size` as the occupancy contract.
+
+## Consequences
+
+- Occupancy surfaces can treat the payload as complete for the visible window.
+- List pagination and occupancy reads stay separate mental models and APIs.
+- Callers must keep UI ranges inside the window cap; Month/Week/Day/Grid visible ranges from the portal fit.
+- Do not reintroduce silent truncation via paginated List pages for Calendar/Grid without superseding this ADR.

--- a/portal/application/facility/booking_service.py
+++ b/portal/application/facility/booking_service.py
@@ -2,7 +2,7 @@
 Facility booking admin application service.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID, uuid4
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from portal.application.facility.commands import (
     BookingPagesQueryCommand,
+    BookingRangeQueryCommand,
     CancelBookingCommand,
     CreateBookingCommand,
     PreviewQuoteCommand,
@@ -17,10 +18,18 @@ from portal.application.facility.commands import (
     UpdateBookingCommand,
 )
 from portal.application.facility.pricing_service import PricingService
-from portal.application.facility.results import BookingDetailResult, BookingListItemResult, BookingPageResult
+from portal.application.facility.results import BookingDetailResult, BookingListItemResult, BookingPageResult, BookingRangeResult
 from portal.application.org.results import CreateIdResult
 from portal.application.system.setting_service import SettingService
-from portal.domain.facility.constants import BookingErrorCode, BookingSlotStatus, BookingStatus, BookingType, FacilityErrorCode, RentalPolicySettingKey
+from portal.domain.facility.constants import (
+    BOOKING_RANGE_MAX_DAYS,
+    BookingErrorCode,
+    BookingSlotStatus,
+    BookingStatus,
+    BookingType,
+    FacilityErrorCode,
+    RentalPolicySettingKey,
+)
 from portal.domain.org.constants import MinistryStatus
 from portal.exceptions.responses import BadRequestException, ConflictErrorException, ForbiddenException, NotFoundException
 from portal.infrastructure.persistence.repositories.facility.booking_repository import BookingRepository
@@ -70,24 +79,27 @@ class BookingService:
         return BookingPageResult(page=command.page, page_size=command.page_size, total=count, items=items)
 
     @distributed_trace()
+    async def get_booking_range(self, command: BookingRangeQueryCommand) -> BookingRangeResult:
+        if command.date_to <= command.date_from:
+            raise BadRequestException(detail="date_to must be after date_from", error_code=FacilityErrorCode.BOOKING_INVALID_TIME_RANGE.value)
+        if command.date_to - command.date_from > timedelta(days=BOOKING_RANGE_MAX_DAYS):
+            raise BadRequestException(
+                detail=f"Booking range window must be at most {BOOKING_RANGE_MAX_DAYS} days", error_code=FacilityErrorCode.BOOKING_RANGE_WINDOW_TOO_LARGE.value
+            )
+        items = await self._repository.fetch_range(command, self._resolved_locale_id())
+        return BookingRangeResult(items=items)
+
+    @distributed_trace()
     async def get_booking_by_id(self, booking_id: UUID) -> BookingDetailResult:
         row = await self._repository.get_detail(booking_id, self._resolved_locale_id())
         if not row:
-            raise NotFoundException(
-                detail="Booking not found",
-                error_code=BookingErrorCode.NOT_FOUND.value,
-                context={"booking_id": str(booking_id)},
-            )
+            raise NotFoundException(detail="Booking not found", error_code=BookingErrorCode.NOT_FOUND.value, context={"booking_id": str(booking_id)})
         return row
 
     @distributed_trace()
     async def cancel_booking(self, booking_id: UUID, command: CancelBookingCommand) -> None:
         if not await self._repository.exists_by_id(booking_id):
-            raise NotFoundException(
-                detail="Booking not found",
-                error_code=BookingErrorCode.NOT_FOUND.value,
-                context={"booking_id": str(booking_id)},
-            )
+            raise NotFoundException(detail="Booking not found", error_code=BookingErrorCode.NOT_FOUND.value, context={"booking_id": str(booking_id)})
         cancelled_by_id = self._user_ctx.user_id if self._user_ctx else None
         cancel_slots = command.scope != "series"
         await self._repository.cancel_booking(

--- a/portal/application/facility/commands.py
+++ b/portal/application/facility/commands.py
@@ -226,6 +226,14 @@ class BookingPagesQueryCommand(PagesQueryCommand):
     date_to: Optional[datetime] = Field(default=None)
 
 
+class BookingRangeQueryCommand(BaseModel):
+    """Non-paginated booking range query for Calendar and Grid."""
+
+    date_from: datetime = Field(...)
+    date_to: datetime = Field(...)
+    include_cancelled: bool = Field(default=False)
+
+
 class OverrideLogPagesQueryCommand(PagesQueryCommand):
     """Paginated override audit log filters."""
 
@@ -285,6 +293,7 @@ class RoomAvailabilityQueryCommand(BaseModel):
 __all__ = [
     "ReplaceMinistryMembersCommand",
     "BookingPagesQueryCommand",
+    "BookingRangeQueryCommand",
     "BookingRoomLineCommand",
     "BulkIdsCommand",
     "CancelBookingCommand",

--- a/portal/application/facility/mappers.py
+++ b/portal/application/facility/mappers.py
@@ -460,6 +460,15 @@ def booking_pages_query_to_command(model) -> "BookingPagesQueryCommand":
     )
 
 
+def booking_range_query_to_command(model) -> "BookingRangeQueryCommand":
+    from portal.application.facility.commands import BookingRangeQueryCommand
+    from portal.serializers.admin.v1.facility.booking import AdminBookingRangeQuery
+
+    if not isinstance(model, AdminBookingRangeQuery):
+        raise TypeError("Expected AdminBookingRangeQuery")
+    return BookingRangeQueryCommand(date_from=model.date_from, date_to=model.date_to, include_cancelled=model.include_cancelled)
+
+
 def override_log_pages_query_to_command(model) -> "OverrideLogPagesQueryCommand":
     from portal.application.facility.commands import OverrideLogPagesQueryCommand
     from portal.serializers.admin.v1.facility.override_log import AdminOverrideLogQuery
@@ -520,6 +529,12 @@ def booking_page_to_api(result) -> "AdminBookingPages":
     return AdminBookingPages(
         page=result.page, page_size=result.page_size, total=result.total, items=[AdminBookingDetail.model_validate(item.model_dump()) for item in result.items]
     )
+
+
+def booking_range_to_api(result) -> "AdminBookingRange":
+    from portal.serializers.admin.v1.facility.booking import AdminBookingListItem, AdminBookingRange
+
+    return AdminBookingRange(items=[AdminBookingListItem.model_validate(item.model_dump()) for item in result.items])
 
 
 def booking_detail_to_api(result) -> "AdminBookingDetail":

--- a/portal/application/facility/results.py
+++ b/portal/application/facility/results.py
@@ -386,6 +386,12 @@ class BookingPageResult(BaseModel):
     items: list[BookingListItemResult] = Field(default_factory=list)
 
 
+class BookingRangeResult(BaseModel):
+    """Complete booking set for a Calendar/Grid time window."""
+
+    items: list[BookingListItemResult] = Field(default_factory=list)
+
+
 class OverrideLogResult(UUIDBaseModel):
     """Override audit log row."""
 

--- a/portal/domain/facility/constants.py
+++ b/portal/domain/facility/constants.py
@@ -15,6 +15,9 @@ class BookingType(str, Enum):
 # recurrence_rule on facility.booking stores iCal RRULE only (RFC 5545), e.g. FREQ=WEEKLY;BYDAY=TU.
 # Use booking.start_at as the series DTSTART; recurrence_end_at bounds the series end.
 
+# Max inclusive span for Booking range query (Calendar / Grid visible window).
+BOOKING_RANGE_MAX_DAYS = 62
+
 
 class BookingStatus(str, Enum):
     """Booking lifecycle status."""
@@ -126,3 +129,4 @@ class FacilityErrorCode(str, Enum):
     BOOKING_ROOMS_REQUIRED = "FACILITY_BOOKING_ROOMS_REQUIRED"
     BOOKING_MAX_ROOMS = "FACILITY_BOOKING_MAX_ROOMS"
     BOOKING_MINISTRY_INACTIVE = "FACILITY_BOOKING_MINISTRY_INACTIVE"
+    BOOKING_RANGE_WINDOW_TOO_LARGE = "FACILITY_BOOKING_RANGE_WINDOW_TOO_LARGE"

--- a/portal/infrastructure/persistence/repositories/facility/booking_repository.py
+++ b/portal/infrastructure/persistence/repositories/facility/booking_repository.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from portal.application.facility.commands import BookingPagesQueryCommand, UpdateBookingCommand
+from portal.application.facility.commands import BookingPagesQueryCommand, BookingRangeQueryCommand, UpdateBookingCommand
 from portal.application.facility.results import BookingDetailResult, BookingListItemResult, BookingRoomLineResult, BookingSlotResult
 from portal.domain.facility.constants import BookingSlotStatus, BookingStatus
 from portal.libs.database import Session
@@ -129,6 +129,30 @@ class BookingRepository:
                 for item in items
             ]
         return items, count
+
+    async def fetch_range(self, model: BookingRangeQueryCommand, locale_id: Optional[UUID]) -> list[BookingListItemResult]:
+        items = await (
+            self._list_query(locale_id)
+            .where(FacilityBooking.is_deleted == False)
+            .where(FacilityBooking.start_at < model.date_to)
+            .where(FacilityBooking.end_at > model.date_from)
+            .where(not model.include_cancelled, lambda: FacilityBooking.status != BookingStatus.CANCELLED.value)
+            .order_by(FacilityBooking.start_at.asc())
+            .fetch(as_model=BookingListItemResult)
+        )
+        items = items or []
+        if items:
+            ids_by_booking_id, names_by_booking_id = await self._fetch_facility_lines_by_booking_ids([item.id for item in items], locale_id)
+            items = [
+                item.model_copy(
+                    update={
+                        "facility_ids": ids_by_booking_id.get(item.id) or [],
+                        "facility_names": names_by_booking_id.get(item.id) or ([item.facility_name] if item.facility_name else []),
+                    }
+                )
+                for item in items
+            ]
+        return items
 
     @staticmethod
     def group_facility_lines(rows: list[dict[str, Any]]) -> tuple[dict[UUID, list[UUID]], dict[UUID, list[str]]]:

--- a/portal/routers/admin/v1/facility/booking.py
+++ b/portal/routers/admin/v1/facility/booking.py
@@ -13,6 +13,8 @@ from portal.application.facility.mappers import (
     booking_detail_to_api,
     booking_page_to_api,
     booking_pages_query_to_command,
+    booking_range_query_to_command,
+    booking_range_to_api,
     cancel_booking_to_command,
     create_booking_to_command,
     create_id_result_to_api,
@@ -27,6 +29,8 @@ from portal.serializers.admin.v1.facility.booking import (
     AdminBookingDetail,
     AdminBookingPages,
     AdminBookingQuery,
+    AdminBookingRange,
+    AdminBookingRangeQuery,
     AdminBookingUpdate,
 )
 from portal.serializers.mixins.model_mixins import UUIDBaseModel
@@ -39,6 +43,15 @@ router: AuthRouter = AuthRouter(is_admin=True)
 async def get_booking_pages(query_model: Annotated[AdminBookingQuery, Query()], booking_service: BookingService = Depends(Provide[Container.booking_service])):
     result = await booking_service.get_booking_pages(command=booking_pages_query_to_command(query_model))
     return booking_page_to_api(result)
+
+
+@router.get(path="/range", status_code=status.HTTP_200_OK, response_model=AdminBookingRange, permissions=[Permission.FACILITY_BOOKING.read])
+@inject
+async def get_booking_range(
+    query_model: Annotated[AdminBookingRangeQuery, Query()], booking_service: BookingService = Depends(Provide[Container.booking_service])
+):
+    result = await booking_service.get_booking_range(command=booking_range_query_to_command(query_model))
+    return booking_range_to_api(result)
 
 
 @router.post(path="", status_code=status.HTTP_201_CREATED, response_model=UUIDBaseModel, permissions=[Permission.FACILITY_BOOKING.create])

--- a/portal/serializers/admin/v1/facility/booking.py
+++ b/portal/serializers/admin/v1/facility/booking.py
@@ -77,6 +77,20 @@ class AdminBookingPages(PaginationBaseResponseModel):
     items: list[AdminBookingListItem] = Field(default_factory=list)
 
 
+class AdminBookingRangeQuery(BaseModel):
+    """Booking range query filters for Calendar and Grid."""
+
+    date_from: datetime = Field(...)
+    date_to: datetime = Field(...)
+    include_cancelled: bool = Field(default=False)
+
+
+class AdminBookingRange(BaseModel):
+    """Complete booking set for a visible time window."""
+
+    items: list[AdminBookingListItem] = Field(default_factory=list)
+
+
 class AdminBookingDetail(AdminBookingListItem):
     """Booking detail."""
 

--- a/tests/application/facility/test_booking_service.py
+++ b/tests/application/facility/test_booking_service.py
@@ -2,18 +2,19 @@
 BookingService unit tests.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 
 from portal.application.facility.booking_service import BookingService
-from portal.application.facility.commands import BookingRoomLineCommand, CancelBookingCommand
+from portal.application.facility.commands import BookingRangeQueryCommand, BookingRoomLineCommand, CancelBookingCommand
 from portal.application.facility.results import BookingDetailResult
-from portal.domain.facility.constants import RentalPolicySettingKey
+from portal.domain.facility.constants import BookingStatus, RentalPolicySettingKey
 from portal.exceptions.responses import BadRequestException, ConflictErrorException, ForbiddenException, NotFoundException
 from tests.fixtures.facility.factories import (
+    make_booking_list_item,
     make_create_booking_command,
     make_ministry_detail,
     make_preview_quote_result,
@@ -303,3 +304,87 @@ async def test_create_booking_scheduling_conflict_is_first_fail(monkeypatch):
         await service.create_booking(command)
     assert exc_info.value.context == {"facility_id": str(first_room_id)}
     assert exc_info.value.error_code == "FACILITY_BOOKING_SCHEDULING_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_get_booking_range_rejects_oversize_window():
+    date_from = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    date_to = date_from + timedelta(days=62, seconds=1)
+    service = _booking_service(StubBookingRepository())
+    with pytest.raises(BadRequestException) as exc_info:
+        await service.get_booking_range(BookingRangeQueryCommand(date_from=date_from, date_to=date_to))
+    assert exc_info.value.error_code == "FACILITY_BOOKING_RANGE_WINDOW_TOO_LARGE"
+
+
+@pytest.mark.asyncio
+async def test_get_booking_range_includes_bookings_that_span_window_edge():
+    """Overlap match: booking starts before window and ends inside; start-in-window alone would miss it."""
+    window_start = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 8, 0, 0, tzinfo=timezone.utc)
+    spanning = make_booking_list_item(
+        start_at=datetime(2026, 4, 30, 22, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 1, 2, 0, tzinfo=timezone.utc), status=BookingStatus.CONFIRMED.value
+    )
+    starts_inside = make_booking_list_item(
+        start_at=datetime(2026, 5, 2, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CONFIRMED.value
+    )
+    entirely_before = make_booking_list_item(
+        start_at=datetime(2026, 4, 29, 10, 0, tzinfo=timezone.utc),
+        end_at=datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc),
+        status=BookingStatus.CONFIRMED.value,
+    )
+    stub = StubBookingRepository(range_items=[spanning, starts_inside, entirely_before])
+    service = _booking_service(stub)
+    result = await service.get_booking_range(BookingRangeQueryCommand(date_from=window_start, date_to=window_end))
+    returned_ids = {item.id for item in result.items}
+    assert spanning.id in returned_ids
+    assert starts_inside.id in returned_ids
+    assert entirely_before.id not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_get_booking_range_excludes_cancelled_by_default():
+    window_start = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 8, 0, 0, tzinfo=timezone.utc)
+    confirmed = make_booking_list_item(
+        start_at=datetime(2026, 5, 2, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CONFIRMED.value
+    )
+    cancelled = make_booking_list_item(
+        start_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CANCELLED.value
+    )
+    stub = StubBookingRepository(range_items=[confirmed, cancelled])
+    service = _booking_service(stub)
+    result = await service.get_booking_range(BookingRangeQueryCommand(date_from=window_start, date_to=window_end))
+    returned_ids = {item.id for item in result.items}
+    assert confirmed.id in returned_ids
+    assert cancelled.id not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_get_booking_range_include_cancelled_flag():
+    window_start = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 8, 0, 0, tzinfo=timezone.utc)
+    cancelled = make_booking_list_item(
+        start_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CANCELLED.value
+    )
+    stub = StubBookingRepository(range_items=[cancelled])
+    service = _booking_service(stub)
+    result = await service.get_booking_range(BookingRangeQueryCommand(date_from=window_start, date_to=window_end, include_cancelled=True))
+    assert {item.id for item in result.items} == {cancelled.id}
+
+
+@pytest.mark.asyncio
+async def test_get_booking_range_excludes_soft_deleted():
+    window_start = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 8, 0, 0, tzinfo=timezone.utc)
+    active = make_booking_list_item(
+        start_at=datetime(2026, 5, 2, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CONFIRMED.value
+    )
+    deleted = make_booking_list_item(
+        start_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc), end_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc), status=BookingStatus.CONFIRMED.value
+    )
+    stub = StubBookingRepository(range_items=[active, deleted], deleted_ids={deleted.id})
+    service = _booking_service(stub)
+    result = await service.get_booking_range(BookingRangeQueryCommand(date_from=window_start, date_to=window_end))
+    returned_ids = {item.id for item in result.items}
+    assert active.id in returned_ids
+    assert deleted.id not in returned_ids

--- a/tests/fixtures/facility/factories.py
+++ b/tests/fixtures/facility/factories.py
@@ -22,6 +22,7 @@ from portal.application.facility.commands import (
     UpdateBookingCommand,
 )
 from portal.application.facility.results import (
+    BookingListItemResult,
     DiscountRuleResult,
     MinistryDetailResult,
     PreviewQuoteResult,
@@ -237,6 +238,28 @@ def make_create_rental_rate_template_command(name: str = "Hourly") -> CreateRent
 
 def make_create_rental_rate_command(facility_id: UUID, template_id: UUID | None = None) -> CreateRentalRateCommand:
     return CreateRentalRateCommand(facility_id=facility_id, template_id=template_id or new_uuid(), is_active=True)
+
+
+def make_booking_list_item(
+    *,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    status: str = "confirmed",
+    booking_id: UUID | None = None,
+    user_id: UUID | None = None,
+    facility_id: UUID | None = None,
+) -> BookingListItemResult:
+    room_id = facility_id or new_uuid()
+    return BookingListItemResult(
+        id=booking_id or new_uuid(),
+        user_id=user_id or new_uuid(),
+        facility_id=room_id,
+        facility_ids=[room_id],
+        booking_type="one_time",
+        start_at=start_at or datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc),
+        end_at=end_at or datetime(2026, 5, 1, 14, 0, tzinfo=timezone.utc),
+        status=status,
+    )
 
 
 def make_update_booking_command(facility_id: UUID | None = None, start_at: datetime | None = None, end_at: datetime | None = None) -> UpdateBookingCommand:

--- a/tests/fixtures/facility/stubs.py
+++ b/tests/fixtures/facility/stubs.py
@@ -9,9 +9,10 @@ from uuid import UUID
 
 from asyncpg import UniqueViolationError
 
-from portal.application.facility.commands import BookingPagesQueryCommand, OverrideLogPagesQueryCommand, PagesQueryCommand
+from portal.application.facility.commands import BookingPagesQueryCommand, BookingRangeQueryCommand, OverrideLogPagesQueryCommand, PagesQueryCommand
 from portal.application.facility.results import (
     BookingDetailResult,
+    BookingListItemResult,
     DiscountRuleResult,
     MinistryDetailResult,
     OverrideLogResult,
@@ -20,7 +21,7 @@ from portal.application.facility.results import (
     RoomSlotTemplateResult,
     SurchargeResult,
 )
-from portal.domain.facility.constants import RentalPolicySettingKey
+from portal.domain.facility.constants import BookingStatus, RentalPolicySettingKey
 from portal.infrastructure.persistence.repositories.facility.rental_repository import RentalRepository
 
 
@@ -237,16 +238,27 @@ class StubRoomRepository:
 class StubBookingRepository:
     """In-memory booking stub."""
 
-    def __init__(self, exists: bool = True, booking_meta: dict | None = None, has_overlap: bool = False, detail: BookingDetailResult | None = None):
+    def __init__(
+        self,
+        exists: bool = True,
+        booking_meta: dict | None = None,
+        has_overlap: bool = False,
+        detail: BookingDetailResult | None = None,
+        range_items: list[BookingListItemResult] | None = None,
+        deleted_ids: set[UUID] | None = None,
+    ):
         self.exists = exists
         self.booking_meta = booking_meta or {"booking_type": "one_time", "currency": "CAD"}
         self.has_overlap = has_overlap
         self.detail = detail
+        self.range_items = range_items or []
+        self.deleted_ids = deleted_ids or set()
         self.cancel_calls: list[dict] = []
         self.insert_calls: list[dict] = []
         self.update_header_calls: list[dict] = []
         self.replace_rooms_calls: list = []
         self.replace_slots_calls: list = []
+        self.fetch_range_calls: list[BookingRangeQueryCommand] = []
 
     async def exists_by_id(self, booking_id: UUID) -> bool:
         return self.exists
@@ -279,6 +291,19 @@ class StubBookingRepository:
 
     async def fetch_pages(self, command: BookingPagesQueryCommand, locale_id):
         return [], 0
+
+    async def fetch_range(self, command: BookingRangeQueryCommand, locale_id) -> list[BookingListItemResult]:
+        self.fetch_range_calls.append(command)
+        items: list[BookingListItemResult] = []
+        for item in self.range_items:
+            if item.id in self.deleted_ids:
+                continue
+            if not (item.start_at < command.date_to and item.end_at > command.date_from):
+                continue
+            if not command.include_cancelled and item.status == BookingStatus.CANCELLED.value:
+                continue
+            items.append(item)
+        return items
 
 
 class StubRoomSlotTemplateRepository:


### PR DESCRIPTION
## Summary

Adds a dedicated non-paginated admin Booking range query so Calendar and Grid can load a complete window of overlapping bookings instead of relying on paginated List `pages` with a large page size. List `pages` behavior is unchanged.

Closes #76

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- New endpoint: `GET /admin/api/v1/facility/bookings/range` with required `date_from` / `date_to` and optional `include_cancelled`
- Match rule: interval overlap (`start_at < date_to` and `end_at > date_from`)
- Cancelled bookings excluded by default; soft-deleted bookings never returned
- Window longer than 62 days rejected (`FACILITY_BOOKING_RANGE_WINDOW_TOO_LARGE`)
- Response grain matches booking list items for occupancy surfaces
- Documents ADR 0007 and CONTEXT term **Booking range query**

## Testing

- [x] `uv run pytest tests/application/facility/test_booking_service.py -k get_booking_range`
- [x] `uv run pytest` (pre-existing failures unrelated to this change: `BookingErrorCode.NOT_FOUND`, `RENTAL_RATE_BINDING_EXISTS`)

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)