### PR TITLE
feat: preview and cascade File associations on Content File delete

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,18 @@ _Avoid_: generic "conflict", treating Blackout as the same failure, parsing the 
 A room-closed interval that makes the room unbookable. Overlap with a Blackout is a distinct rejection from a Scheduling Conflict; the client must show a different prompt.
 _Avoid_: scheduling conflict, "closed" without naming the Blackout rule
 
+**Room gallery**:
+An optional ordered set of at most ten image Content Files bound to one Room. Each file appears at most once in that gallery. The same Content File may appear in many Rooms' galleries. Order is Operator-controlled (including drag reorder on the Room form). Saving the Room replaces the whole gallery. Soft-deleting a Room keeps its File associations so restore brings the gallery back. Admin Room list does not include gallery files; Room detail (and create response) does, with signed URLs for preview.
+_Avoid_: cover, required gallery, room image URL field, treating the first file as a separate Cover entity in v1 admin, unbounded gallery, clearing associations on Room soft-delete, non-image Content Files, duplicate files in one gallery, list-page thumbnails as the v1 contract, a separate files GET for v1 admin preview
+
+**Content File**:
+A stored media object in the content library (metadata plus blob). Rooms bind to Content Files; they do not own uploads as a separate room-file type.
+_Avoid_: attachment, asset, location file, inline URL as the bound object
+
+**File association**:
+The bind between one Content File and one resource (for example a Room). A Room gallery association is identified by resource kind `facility.room`, not by a class or table name. Binding or reordering a Room gallery is part of editing that Room. Putting a new file into the content library (including upload inside the Room picker) is a Content File upload. Deleting a Content File is allowed while associations exist: one confirmation lists every selected file's bound resources by name or code, including soft-deleted Rooms marked as deleted; then the files and all of their File associations are removed together. No orphan association rows remain. A gallery of ten images cannot accept another file; the picker is disabled and the server also rejects an over-cap save.
+_Avoid_: blocking delete until unbind, leftover association rows after file delete, silent delete with no association warning, a count-only warning with no names, hiding soft-deleted Rooms from the warning, handler class names as resource kind, treating library upload as only a Room permission, toast for over-cap instead of blocking the picker
+
 ### Org / ministry
 
 **Ministry**:

--- a/docs/adr/0009-content-file-delete-clears-associations.md
+++ b/docs/adr/0009-content-file-delete-clears-associations.md
@@ -1,0 +1,17 @@
+# Deleting a Content File clears File associations after a named warning
+
+Operators may delete a Content File that is still in a Room gallery (or other File associations). We do **not** block delete until unbind. Confirming delete removes the Content File **and every File association** for that file so no orphan rows remain.
+
+The warning payload lists bound resources by name or code, **including soft-deleted Rooms**, marked as deleted. Soft-delete of a Room keeps associations so restore restores the gallery; hiding those Rooms would make delete look unused while restore would lose images.
+
+## Considered Options
+
+- **Reject delete while any association exists** — rejected: forces a separate unbind on every Room first.
+- **Delete the file and leave association rows** — rejected: broken gallery reads and restore surprises.
+- **Warn with counts only, or omit soft-deleted Rooms** — rejected: operators cannot tell what they are breaking.
+
+## Consequences
+
+- Bulk delete uses one confirmation over the selected files, then one cascade of files + associations.
+- Admin clients must render the named list (including deleted Rooms), not only a count.
+- Member-facing gallery is out of scope for this decision.

--- a/portal/application/content/commands.py
+++ b/portal/application/content/commands.py
@@ -27,6 +27,12 @@ class BulkDeleteFilesCommand(BaseModel):
     ids: list[UUID] = Field(...)
 
 
+class PreviewFileAssociationsCommand(BaseModel):
+    """List named File associations for selected files."""
+
+    ids: list[UUID] = Field(...)
+
+
 class UpdateFileAssociationCommand(BaseModel):
     """Replace file associations for a resource."""
 

--- a/portal/application/content/file_service.py
+++ b/portal/application/content/file_service.py
@@ -18,11 +18,18 @@ from azure.core.exceptions import AzureError
 from fastapi import status
 from PIL import Image
 
-from portal.application.content.commands import BulkDeleteFilesCommand, FilePagesQueryCommand, UpdateFileAssociationCommand, UploadFileCommand
+from portal.application.content.commands import (
+    BulkDeleteFilesCommand,
+    FilePagesQueryCommand,
+    PreviewFileAssociationsCommand,
+    UpdateFileAssociationCommand,
+    UploadFileCommand,
+)
 from portal.application.content.results import (
     BatchUploadFilesResult,
     BulkDeleteFilesResult,
     FailedUploadFileResult,
+    FileAssociationPreviewResult,
     FileBaseResult,
     FileDetailResult,
     FileGridItemResult,
@@ -37,6 +44,7 @@ from portal.domain.content.ports import FileCachePort, FileRepositoryPort, FileS
 from portal.domain.rbac.ports import RbacAuditPort
 from portal.exceptions.responses import ApiBaseException, BadRequestException, ConflictErrorException
 from portal.libs.consts.enums import OperationType
+from portal.libs.contexts.request_context import get_resolved_locale_id
 from portal.libs.tracing.distributed_trace import distributed_trace
 
 
@@ -187,6 +195,10 @@ class FileService:
         failed_items = [file_key_mapping[key] for key in keys if key not in success_keys and key in file_key_mapping]
         if success_keys:
             await self._repository.mark_deleted_by_keys(success_keys)
+            success_file_ids = [file_key_mapping[key].id for key in success_keys if key in file_key_mapping]
+            resource_ids = await self._repository.delete_associations_by_file_ids(success_file_ids)
+            for resource_id in set(resource_ids):
+                await self._cache.invalidate_resource_association(resource_id)
             for key in success_keys:
                 file_item = file_key_mapping.get(key)
                 if file_item:
@@ -195,6 +207,11 @@ class FileService:
                 OperationType.DELETE, operation_code=CONTENT_FILE_TABLE, old_data={"file_keys": success_keys}, new_data={"status": FileStatus.DELETED.value}
             )
         return BulkDeleteFilesResult(success_count=len(success_keys), failed_items=failed_items or None)
+
+    @distributed_trace()
+    async def preview_file_associations(self, command: PreviewFileAssociationsCommand) -> FileAssociationPreviewResult:
+        items = await self._repository.fetch_association_preview_by_file_ids(command.ids, get_resolved_locale_id())
+        return FileAssociationPreviewResult(items=items or [])
 
     @distributed_trace()
     async def update_file_association(self, command: UpdateFileAssociationCommand) -> None:

--- a/portal/application/content/mappers.py
+++ b/portal/application/content/mappers.py
@@ -4,10 +4,12 @@ Map between content file API serializers and application commands/results.
 
 from fastapi import UploadFile
 
-from portal.application.content.commands import BulkDeleteFilesCommand, FilePagesQueryCommand, UploadFileCommand
+from portal.application.content.commands import BulkDeleteFilesCommand, FilePagesQueryCommand, PreviewFileAssociationsCommand, UploadFileCommand
 from portal.application.content.results import (
     BatchUploadFilesResult,
     BulkDeleteFilesResult,
+    FileAssociationBindingResult,
+    FileAssociationPreviewResult,
     FileBaseResult,
     FileCategoryStatsResult,
     FileGridItemResult,
@@ -20,6 +22,8 @@ from portal.serializers.admin.v1.file import (
     AdminBatchFileUploadResponseModel,
     AdminBulkActionResponseModel,
     AdminFailedUploadFile,
+    AdminFileAssociationBinding,
+    AdminFileAssociationPreview,
     AdminFileBase,
     AdminFileBulkAction,
     AdminFileCategoryStats,
@@ -59,6 +63,10 @@ def pages_query_to_command(model: AdminFileQuery) -> FilePagesQueryCommand:
 
 def bulk_action_to_command(model: AdminFileBulkAction) -> BulkDeleteFilesCommand:
     return BulkDeleteFilesCommand(ids=model.ids)
+
+
+def preview_associations_to_command(model: AdminFileBulkAction) -> PreviewFileAssociationsCommand:
+    return PreviewFileAssociationsCommand(ids=model.ids)
 
 
 def file_base_result_to_api(result: FileBaseResult) -> AdminFileBase:
@@ -121,3 +129,17 @@ def bulk_delete_result_to_api(result: BulkDeleteFilesResult) -> AdminBulkActionR
     if result.failed_items:
         failed_items = [file_base_result_to_api(item) for item in result.failed_items]
     return AdminBulkActionResponseModel(success_count=result.success_count, failed_items=failed_items)
+
+
+def association_binding_to_api(result: FileAssociationBindingResult) -> AdminFileAssociationBinding:
+    return AdminFileAssociationBinding(
+        file_id=result.file_id,
+        resource_kind=result.resource_kind,
+        resource_id=result.resource_id,
+        display_name=result.display_name,
+        is_deleted=result.is_deleted,
+    )
+
+
+def association_preview_to_api(result: FileAssociationPreviewResult) -> AdminFileAssociationPreview:
+    return AdminFileAssociationPreview(items=[association_binding_to_api(item) for item in result.items])

--- a/portal/application/content/results.py
+++ b/portal/application/content/results.py
@@ -97,6 +97,22 @@ class BulkDeleteFilesResult(BaseModel):
     failed_items: Optional[list[FileBaseResult]] = Field(default=None)
 
 
+class FileAssociationBindingResult(BaseModel):
+    """One File association with a named resource for delete preview."""
+
+    file_id: UUID = Field(...)
+    resource_kind: str = Field(...)
+    resource_id: UUID = Field(...)
+    display_name: str = Field(...)
+    is_deleted: bool = Field(...)
+
+
+class FileAssociationPreviewResult(BaseModel):
+    """Named File associations for selected files."""
+
+    items: list[FileAssociationBindingResult] = Field(default_factory=list)
+
+
 class SignedUrlFileByResourceResult(FileBaseResult):
     """File row joined with resource association."""
 

--- a/portal/domain/content/ports.py
+++ b/portal/domain/content/ports.py
@@ -6,7 +6,14 @@ from typing import Any, Optional, Protocol
 from uuid import UUID
 
 from portal.application.content.commands import FilePagesQueryCommand
-from portal.application.content.results import FileBaseResult, FileDetailResult, FileGridItemResult, FileSummaryResult, SignedUrlFileByResourceResult
+from portal.application.content.results import (
+    FileAssociationBindingResult,
+    FileBaseResult,
+    FileDetailResult,
+    FileGridItemResult,
+    FileSummaryResult,
+    SignedUrlFileByResourceResult,
+)
 
 
 class FileRepositoryPort(Protocol):
@@ -35,6 +42,10 @@ class FileRepositoryPort(Protocol):
     async def fetch_by_resource_id(self, resource_id: UUID) -> list[FileGridItemResult]: ...
 
     async def fetch_associations_by_resource_ids(self, resource_ids: list[UUID]) -> list[SignedUrlFileByResourceResult]: ...
+
+    async def fetch_association_preview_by_file_ids(self, file_ids: list[UUID], locale_id: Optional[UUID]) -> list[FileAssociationBindingResult]: ...
+
+    async def delete_associations_by_file_ids(self, file_ids: list[UUID]) -> list[UUID]: ...
 
 
 class FileStoragePort(Protocol):

--- a/portal/infrastructure/persistence/repositories/content/file_repository.py
+++ b/portal/infrastructure/persistence/repositories/content/file_repository.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 
 from portal.application.content.commands import FilePagesQueryCommand
 from portal.application.content.results import (
+    FileAssociationBindingResult,
     FileBaseResult,
     FileCategoryStatsResult,
     FileDetailResult,
@@ -16,10 +17,10 @@ from portal.application.content.results import (
     FileSummaryResult,
     SignedUrlFileByResourceResult,
 )
-from portal.domain.content.constants import FileStatus, MediaCategory
+from portal.domain.content.constants import FILE_RESOURCE_KIND_FACILITY_ROOM, FileStatus, MediaCategory
 from portal.libs.database import Session
 from portal.libs.database.execute_result import affected_rows
-from portal.models import ContentFile, ContentFileAssociation
+from portal.models import ContentFile, ContentFileAssociation, FacilityRoom, FacilityRoomTranslation
 
 
 class FileRepository:
@@ -193,3 +194,42 @@ class FileRepository:
             .fetch(as_model=SignedUrlFileByResourceResult)
         )
         return items or []
+
+    async def fetch_association_preview_by_file_ids(self, file_ids: list[UUID], locale_id: Optional[UUID]) -> list[FileAssociationBindingResult]:
+        if not file_ids:
+            return []
+        room_name = FacilityRoom.code
+        if locale_id:
+            room_name = sa.func.coalesce(
+                sa.select(FacilityRoomTranslation.name)
+                .where(FacilityRoomTranslation.room_id == FacilityRoom.id, FacilityRoomTranslation.locale_id == locale_id)
+                .limit(1)
+                .scalar_subquery(),
+                FacilityRoom.code,
+            )
+        display_name = sa.func.coalesce(room_name, sa.cast(ContentFileAssociation.resource_id, sa.String))
+        items = await (
+            self._session.select(
+                ContentFileAssociation.file_id,
+                ContentFileAssociation.resource_name.label("resource_kind"),
+                ContentFileAssociation.resource_id,
+                display_name.label("display_name"),
+                sa.func.coalesce(FacilityRoom.is_deleted, False).label("is_deleted"),
+            )
+            .select_from(ContentFileAssociation)
+            .outerjoin(
+                FacilityRoom,
+                sa.and_(FacilityRoom.id == ContentFileAssociation.resource_id, ContentFileAssociation.resource_name == FILE_RESOURCE_KIND_FACILITY_ROOM),
+            )
+            .where(ContentFileAssociation.file_id.in_(file_ids))
+            .order_by(ContentFileAssociation.file_id, ContentFileAssociation.sequence.asc())
+            .fetch(as_model=FileAssociationBindingResult)
+        )
+        return items or []
+
+    async def delete_associations_by_file_ids(self, file_ids: list[UUID]) -> list[UUID]:
+        if not file_ids:
+            return []
+        resource_ids = await self._session.select(ContentFileAssociation.resource_id).where(ContentFileAssociation.file_id.in_(file_ids)).fetchvals()
+        await self._session.delete(ContentFileAssociation).where(ContentFileAssociation.file_id.in_(file_ids)).execute()
+        return resource_ids or []

--- a/portal/routers/admin/v1/content/file.py
+++ b/portal/routers/admin/v1/content/file.py
@@ -9,12 +9,14 @@ from fastapi import Depends, Query, UploadFile, status
 
 from portal.application.content.file_service import FileService
 from portal.application.content.mappers import (
+    association_preview_to_api,
     batch_upload_result_to_api,
     bulk_action_to_command,
     bulk_delete_result_to_api,
     file_page_result_to_api,
     file_summary_result_to_api,
     pages_query_to_command,
+    preview_associations_to_command,
     upload_file_result_to_api,
     upload_file_to_command,
     upload_files_to_commands,
@@ -27,6 +29,7 @@ from portal.routers.auth_router import AuthRouter
 from portal.serializers.admin.v1.file import (
     AdminBatchFileUploadResponseModel,
     AdminBulkActionResponseModel,
+    AdminFileAssociationPreview,
     AdminFileBulkAction,
     AdminFilePages,
     AdminFileQuery,
@@ -103,6 +106,15 @@ async def upload_multiple_files(
     commands = await upload_files_to_commands(validated_files, upload_source=FileUploadSource.ADMIN)
     result = await file_service.upload_multiple_files(commands)
     return batch_upload_result_to_api(result)
+
+
+@router.post(
+    path="/association-preview", status_code=status.HTTP_200_OK, response_model=AdminFileAssociationPreview, permissions=[Permission.CONTENT_FILE.read]
+)
+@inject
+async def preview_file_associations(model: AdminFileBulkAction, file_service: FileService = Depends(Provide[Container.file_service])):
+    result = await file_service.preview_file_associations(command=preview_associations_to_command(model))
+    return association_preview_to_api(result)
 
 
 @router.delete(

--- a/portal/serializers/admin/v1/file.py
+++ b/portal/serializers/admin/v1/file.py
@@ -102,6 +102,22 @@ class AdminFileBulkAction(BaseModel):
     ids: list[UUID] = Field(..., description="File IDs")
 
 
+class AdminFileAssociationBinding(BaseModel):
+    """Named File association for delete preview."""
+
+    file_id: UUID = Field(..., description="File ID", serialization_alias="fileId")
+    resource_kind: str = Field(..., description="Resource kind token", serialization_alias="resourceKind")
+    resource_id: UUID = Field(..., description="Bound resource ID", serialization_alias="resourceId")
+    display_name: str = Field(..., description="Room name or code", serialization_alias="displayName")
+    is_deleted: bool = Field(..., description="Whether the bound Room is soft-deleted", serialization_alias="isDeleted")
+
+
+class AdminFileAssociationPreview(BaseModel):
+    """Named File associations for selected files."""
+
+    items: list[AdminFileAssociationBinding] = Field(..., description="Bindings")
+
+
 class AdminBulkActionResponseModel(BaseModel):
     """Bulk Action Response Model"""
 

--- a/tests/application/content/test_file_service.py
+++ b/tests/application/content/test_file_service.py
@@ -7,9 +7,15 @@ from uuid import uuid4
 import pytest
 from azure.core.exceptions import AzureError
 
-from portal.application.content.commands import BulkDeleteFilesCommand, FilePagesQueryCommand, UpdateFileAssociationCommand, UploadFileCommand
+from portal.application.content.commands import (
+    BulkDeleteFilesCommand,
+    FilePagesQueryCommand,
+    PreviewFileAssociationsCommand,
+    UpdateFileAssociationCommand,
+    UploadFileCommand,
+)
 from portal.application.content.file_service import FileService
-from portal.application.content.results import FileBaseResult, FileDetailResult, FileGridItemResult
+from portal.application.content.results import FileAssociationBindingResult, FileBaseResult, FileDetailResult, FileGridItemResult
 from portal.domain.content.constants import FILE_RESOURCE_KIND_FACILITY_ROOM, FileStatus, FileUploadSource
 from portal.exceptions.responses import ApiBaseException, BadRequestException
 
@@ -18,9 +24,11 @@ class StubFileRepository:
     def __init__(self):
         self.files: dict = {}
         self.association_rows: list = []
+        self.preview_bindings: list = []
         self.insert_calls: list = []
         self.status_updates: list = []
         self.deleted_keys: list = []
+        self.deleted_association_file_ids: list = []
 
     async def fetch_pages(self, command):
         items = [
@@ -151,6 +159,21 @@ class StubFileRepository:
 
     async def fetch_associations_by_resource_ids(self, resource_ids):
         return []
+
+    async def fetch_association_preview_by_file_ids(self, file_ids, locale_id):
+        return [row for row in self.preview_bindings if row.file_id in file_ids]
+
+    async def delete_associations_by_file_ids(self, file_ids):
+        self.deleted_association_file_ids.extend(file_ids)
+        remaining = []
+        resource_ids = []
+        for row in self.association_rows:
+            if row["file_id"] in file_ids:
+                resource_ids.append(row["resource_id"])
+            else:
+                remaining.append(row)
+        self.association_rows = remaining
+        return resource_ids
 
 
 class StubFileStorage:
@@ -314,6 +337,79 @@ async def test_delete_files_success():
     assert result.success_count == 1
     assert file_id in cache.invalidated_urls
     assert repo.files[file_id].status == FileStatus.DELETED
+
+
+@pytest.mark.asyncio
+async def test_preview_file_associations_includes_names_and_deleted_rooms():
+    repo = StubFileRepository()
+    file_id = uuid4()
+    room_id = uuid4()
+    deleted_room_id = uuid4()
+    repo.preview_bindings = [
+        FileAssociationBindingResult(
+            file_id=file_id, resource_kind=FILE_RESOURCE_KIND_FACILITY_ROOM, resource_id=room_id, display_name="Sanctuary", is_deleted=False
+        ),
+        FileAssociationBindingResult(
+            file_id=file_id, resource_kind=FILE_RESOURCE_KIND_FACILITY_ROOM, resource_id=deleted_room_id, display_name="OLD-HALL", is_deleted=True
+        ),
+    ]
+    service = _make_service(repo=repo)
+
+    result = await service.preview_file_associations(PreviewFileAssociationsCommand(ids=[file_id]))
+
+    assert {(item.display_name, item.is_deleted, item.resource_kind) for item in result.items} == {
+        ("Sanctuary", False, FILE_RESOURCE_KIND_FACILITY_ROOM),
+        ("OLD-HALL", True, FILE_RESOURCE_KIND_FACILITY_ROOM),
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_files_clears_associations_for_deleted_files_only():
+    repo = StubFileRepository()
+    deleted_file_id = uuid4()
+    kept_file_id = uuid4()
+    bound_room_id = uuid4()
+    other_room_id = uuid4()
+    repo.files[deleted_file_id] = FileDetailResult(
+        id=deleted_file_id,
+        original_name="a.png",
+        key="original_files/dev/a.png",
+        storage="azure_blob",
+        bucket="files",
+        region="eastus",
+        status=FileStatus.UPLOADED,
+    )
+    repo.association_rows = [
+        {"resource_id": bound_room_id, "resource_name": FILE_RESOURCE_KIND_FACILITY_ROOM, "file_id": deleted_file_id, "sequence": 0},
+        {"resource_id": other_room_id, "resource_name": FILE_RESOURCE_KIND_FACILITY_ROOM, "file_id": kept_file_id, "sequence": 0},
+    ]
+    cache = StubFileCache()
+    service = _make_service(repo=repo, cache=cache)
+
+    result = await service.delete_files(BulkDeleteFilesCommand(ids=[deleted_file_id]))
+
+    assert result.success_count == 1
+    assert repo.association_rows == [{"resource_id": other_room_id, "resource_name": FILE_RESOURCE_KIND_FACILITY_ROOM, "file_id": kept_file_id, "sequence": 0}]
+    assert bound_room_id in cache.invalidated_associations
+    assert other_room_id not in cache.invalidated_associations
+
+
+@pytest.mark.asyncio
+async def test_delete_files_keeps_associations_when_storage_delete_fails():
+    repo = StubFileRepository()
+    file_id = uuid4()
+    room_id = uuid4()
+    repo.files[file_id] = FileDetailResult(
+        id=file_id, original_name="a.png", key="original_files/dev/a.png", storage="azure_blob", bucket="files", region="eastus", status=FileStatus.UPLOADED
+    )
+    repo.association_rows = [{"resource_id": room_id, "resource_name": FILE_RESOURCE_KIND_FACILITY_ROOM, "file_id": file_id, "sequence": 0}]
+    service = _make_service(repo=repo, storage=StubFileStorage(delete_success=False))
+
+    result = await service.delete_files(BulkDeleteFilesCommand(ids=[file_id]))
+
+    assert result.success_count == 0
+    assert repo.association_rows == [{"resource_id": room_id, "resource_name": FILE_RESOURCE_KIND_FACILITY_ROOM, "file_id": file_id, "sequence": 0}]
+    assert repo.files[file_id].status == FileStatus.UPLOADED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Operators can delete Content Files that are still bound. A named association preview lists each selected file's resources (Room name or code, including soft-deleted Rooms marked deleted). Confirming the existing bulk delete then removes those files and all of their File associations so no orphan rows remain.

Stacked on `feat/80-file-association-replace-scope` (issue #80). Portal confirmation UI is a sibling ticket.

Closes #82

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `POST /admin/api/v1/file/association-preview` with the same file-id body as bulk delete (`CONTENT_FILE.read`).
- Successful `DELETE /file/bulk` deletes associations for files whose blobs were deleted; storage failure leaves associations in place.
- Upload/delete permissions are unchanged.
- ADR 0009 records the named-warning + cascade decision.

## Testing

- [x] `uv run pytest tests/application/content/test_file_service.py`
- [ ] `uv run pytest`

## Checklist

- [x] PR targets **`feat/80-file-association-replace-scope`** (stacked; not `main`)
- [ ] CI green before merge