### PR TITLE
fix: coerce Legal Document translation JSON strings on detail read

### DIFF
--- a/portal/application/content/results.py
+++ b/portal/application/content/results.py
@@ -3,10 +3,11 @@ Content application results (snake_case, no API serialization aliases).
 """
 
 from datetime import date, datetime
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+import ujson
+from pydantic import BaseModel, Field, field_validator
 
 from portal.domain.common.mixins import UUIDBaseModel
 from portal.domain.content.constants import FileStatus, FileUploadSource
@@ -148,6 +149,27 @@ class LegalDocumentDetailResult(LegalDocumentListItemResult):
     """Legal Document detail with locale translations."""
 
     translations: list[LegalDocumentTranslationItemResult] = Field(default_factory=list)
+
+    @field_validator("translations", mode="before")
+    @classmethod
+    def coerce_translation_entries(cls, value: Any) -> list[Any]:
+        """Accept DB aggregate entries that arrive as JSON strings or dicts."""
+        if not value:
+            return []
+        items: list[Any] = []
+        for entry in value:
+            if not entry:
+                continue
+            if isinstance(entry, str):
+                try:
+                    entry = ujson.loads(entry)
+                except ujson.JSONDecodeError:
+                    continue
+            if isinstance(entry, dict):
+                items.append({"locale_id": entry.get("locale_id") or entry.get("localeId"), "body": entry.get("body") or ""})
+            else:
+                items.append(entry)
+        return items
 
 
 class LegalDocumentPageResult(BaseModel):

--- a/portal/infrastructure/persistence/repositories/content/legal_document_repository.py
+++ b/portal/infrastructure/persistence/repositories/content/legal_document_repository.py
@@ -6,11 +6,10 @@ from typing import Any, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-import ujson
 from sqlalchemy.dialects.postgresql import JSONB
 
 from portal.application.content.commands import LegalDocumentPagesQueryCommand
-from portal.application.content.results import LegalDocumentDetailResult, LegalDocumentListItemResult, LegalDocumentTranslationItemResult
+from portal.application.content.results import LegalDocumentDetailResult, LegalDocumentListItemResult
 from portal.libs.database import Session
 from portal.libs.database.execute_result import affected_rows
 from portal.models import ContentLegalDocument, ContentLegalDocumentTranslation, SystemLocale
@@ -85,8 +84,7 @@ class LegalDocumentRepository:
         )
         if not include_deleted:
             query = query.where(ContentLegalDocument.is_deleted == False)
-        row: Optional[LegalDocumentDetailResult] = await query.fetchrow(as_model=LegalDocumentDetailResult)
-        return self._normalize_row(row)
+        return await query.fetchrow(as_model=LegalDocumentDetailResult)
 
     async def get_by_product_kind(self, product: str, kind: str, *, include_deleted: bool = False) -> Optional[LegalDocumentDetailResult]:
         query = (
@@ -111,32 +109,7 @@ class LegalDocumentRepository:
         )
         if not include_deleted:
             query = query.where(ContentLegalDocument.is_deleted == False)
-        row: Optional[LegalDocumentDetailResult] = await query.fetchrow(as_model=LegalDocumentDetailResult)
-        return self._normalize_row(row)
-
-    @staticmethod
-    def _parse_translations(raw: Any) -> list[LegalDocumentTranslationItemResult]:
-        if not raw:
-            return []
-        items = []
-        for entry in raw:
-            if not entry:
-                continue
-            if isinstance(entry, str):
-                try:
-                    entry = ujson.loads(entry)
-                except ujson.JSONDecodeError:
-                    continue
-            items.append(LegalDocumentTranslationItemResult(locale_id=entry.get("locale_id") or entry.get("localeId"), body=entry.get("body") or ""))
-        return items
-
-    def _normalize_row(self, row: Optional[LegalDocumentDetailResult]) -> Optional[LegalDocumentDetailResult]:
-        if not row:
-            return None
-        data = row.model_dump()
-        translations = data.pop("translations", None)
-        data["translations"] = self._parse_translations(translations)
-        return LegalDocumentDetailResult.model_validate(data)
+        return await query.fetchrow(as_model=LegalDocumentDetailResult)
 
     async def insert_document(self, payload: dict[str, Any]) -> None:
         await self._session.insert(ContentLegalDocument).values(payload).execute()

--- a/tests/application/content/test_legal_document_detail_result.py
+++ b/tests/application/content/test_legal_document_detail_result.py
@@ -1,0 +1,61 @@
+"""
+Boundary tests for Legal Document detail translation aggregate coercion.
+"""
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import ujson
+
+from portal.application.content.results import LegalDocumentDetailResult
+from portal.domain.content.constants import LegalDocumentKind, ProductCode
+
+
+def _raw_detail_row(*, translations: list) -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "id": uuid4(),
+        "product": ProductCode.FACILITY_BOOKING.value,
+        "kind": LegalDocumentKind.PRIVACY_POLICY.value,
+        "effective_date": date(2026, 1, 1),
+        "created_at": now,
+        "created_by": None,
+        "updated_at": now,
+        "updated_by": None,
+        "is_deleted": False,
+        "delete_reason": None,
+        "translations": translations,
+    }
+
+
+def test_legal_document_detail_accepts_string_json_translations():
+    locale_en = uuid4()
+    locale_zh = uuid4()
+    raw = _raw_detail_row(
+        translations=[ujson.dumps({"locale_id": str(locale_en), "body": "# Privacy Policy"}), ujson.dumps({"locale_id": str(locale_zh), "body": ""})]
+    )
+
+    result = LegalDocumentDetailResult.model_validate(raw)
+
+    bodies = {item.locale_id: item.body for item in result.translations}
+    assert bodies[locale_en] == "# Privacy Policy"
+    assert bodies[locale_zh] == ""
+
+
+def test_legal_document_detail_accepts_dict_translations():
+    locale_en = uuid4()
+    raw = _raw_detail_row(translations=[{"locale_id": locale_en, "body": "# Terms"}])
+
+    result = LegalDocumentDetailResult.model_validate(raw)
+
+    assert len(result.translations) == 1
+    assert result.translations[0].locale_id == locale_en
+    assert result.translations[0].body == "# Terms"
+
+
+def test_legal_document_detail_empty_translations():
+    raw = _raw_detail_row(translations=[])
+
+    result = LegalDocumentDetailResult.model_validate(raw)
+
+    assert result.translations == []


### PR DESCRIPTION
## Summary

Legal Document detail reads failed with Pydantic `ValidationError` when translation aggregates arrived as JSON **strings** (common after saving Markdown bodies). Coerce string/dict translation entries in `LegalDocumentDetailResult` before typed validation so admin update reload and public product×kind detail succeed while keeping `fetchrow(as_model=…)`.

Closes #99

## Type of change

- [x] Bug fix

## Implementation notes

- `LegalDocumentDetailResult.translations` uses a `before` field validator to parse JSON strings (and accept dicts) into typed translation items.
- Removed the unused post-`as_model` `_normalize_row` / `_parse_translations` path on the repository (coercion now lives on the result model used by `as_model`).
- Out of scope: Portal/Facility UI, soft-delete include-deleted GET, Alembic.

## Testing

- [x] `uv run pytest tests/application/content/ -q`
- [x] `uv run pytest tests/application/content/test_legal_document_detail_result.py -v`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)