### PR TITLE
fix: allow admin Legal Document GET for soft-deleted rows

### DIFF
--- a/portal/application/content/legal_document_service.py
+++ b/portal/application/content/legal_document_service.py
@@ -77,7 +77,7 @@ class LegalDocumentService:
 
     @distributed_trace()
     async def get_legal_document_by_id(self, document_id: UUID) -> LegalDocumentDetailResult:
-        row = await self._repository.get_by_id(document_id)
+        row = await self._repository.get_by_id(document_id, include_deleted=True)
         if not row:
             raise NotFoundException(
                 detail="Legal Document not found", error_code=ContentErrorCode.LEGAL_DOCUMENT_NOT_FOUND.value, context={"document_id": str(document_id)}

--- a/tests/application/content/test_legal_document_service.py
+++ b/tests/application/content/test_legal_document_service.py
@@ -282,6 +282,18 @@ async def test_get_legal_document_by_id_returns_translations():
 
 
 @pytest.mark.asyncio
+async def test_get_legal_document_by_id_includes_soft_deleted():
+    document = _document(is_deleted=True, effective_date=date(2025, 5, 1))
+    service = LegalDocumentService(StubLegalDocumentRepository([document]))
+
+    result = await service.get_legal_document_by_id(document.id)
+
+    assert result.id == document.id
+    assert result.is_deleted is True
+    assert result.effective_date == date(2025, 5, 1)
+
+
+@pytest.mark.asyncio
 async def test_get_legal_document_by_id_not_found():
     service = LegalDocumentService(StubLegalDocumentRepository())
 


### PR DESCRIPTION
## Summary

Admin Legal Document detail GET now includes soft-deleted rows so Portal recycle Context menu View can load translations under Read.

Related: newlife-portal-frontend #53 / https://github.com/efcnewlife/newlife-portal-frontend/pull/55. Follow-up to Effective Date work (#97).

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `get_legal_document_by_id` passes `include_deleted=True` to the repository.
- Public Legal Document GET remains active-only.
- Supersedes mis-aimed https://github.com/efcnewlife/newlife-core-api/pull/101 (wrong branch tip).

## Testing

- [x] `uv run pytest tests/application/content/test_legal_document_service.py`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)