### PR TITLE
feat: send bilingual Graph mail on ministry application submit (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,15 @@ The Admin Portal SPA can sign in with Microsoft and exchange the Entra **ID toke
 4. Ensure `CORS_ALLOWED_ORIGINS` includes the Admin Portal origin.
 5. The portal user must already exist with `is_admin`, `is_active`, and `verified`; matching is by **email** from the token.
 
+#### Microsoft Graph Mail.Send (Ministry Application notifications)
+
+When `GRAPH_MAIL_SEND_ENABLED=true`, successful Ministry Application submit sends bilingual Outlook messages (English first, then Chinese) from `GRAPH_MAIL_SENDER_MAILBOX` via Graph `Mail.Send`:
+
+1. On the same Entra app registration used for `sync-microsoft-users`, add **Application** permission **Microsoft Graph → Mail.Send** and grant **admin consent**.
+2. Set `GRAPH_MAIL_SENDER_MAILBOX` to the system mailbox UPN (the app must be allowed to send as that user).
+3. Set `FACILITY_BOOKING_BASE_URL` to the Facility Booking SPA origin (deep links: `/my-ministry`, `/my-ministry/approvals/{ministryId}`).
+4. Keep `AZURE_TENANT_ID`, `AZURE_APP_CLIENT_ID`, and `AZURE_APP_CLIENT_SECRET` configured (same as directory sync).
+
 ### Docker
 
 Make sure you have Docker installed and running.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ When `GRAPH_MAIL_SEND_ENABLED=true`, successful Ministry Application submit send
 2. Set `GRAPH_MAIL_SENDER_MAILBOX` to the system mailbox UPN (the app must be allowed to send as that user).
 3. Set `FACILITY_BOOKING_BASE_URL` to the Facility Booking SPA origin (deep links: `/my-ministry`, `/my-ministry/approvals/{ministryId}`).
 4. Keep `AZURE_TENANT_ID`, `AZURE_APP_CLIENT_ID`, and `AZURE_APP_CLIENT_SECRET` configured (same as directory sync).
+5. Optional (non-`prod` only): set `GRAPH_MAIL_OVERRIDE_TO` to one or more comma-separated addresses so dev/stg mail never reaches real applicants or incumbents. The subject line is prefixed with `[DEV -> intended@recipient]`.
 
 ### Docker
 

--- a/example.env
+++ b/example.env
@@ -42,5 +42,11 @@ JWT_SECRET_KEY=change-me-in-production
 # AZURE_APP_CLIENT_ID=your-spa-client-id
 # AZURE_APP_CLIENT_SECRET=your-app-client-secret
 # Required for sync-microsoft-users CLI (Graph client credentials, Application permission User.Read.All + admin consent)
+# Ministry application submit emails also require Application permission Mail.Send (admin consent) on the same app registration.
 # Optional: override issuer if you use a custom authority (comma-separated for multiple)
 # AZURE_ALLOWED_ISSUERS=https://login.microsoftonline.com/your-tenant-id/v2.0
+
+# Microsoft Graph Mail.Send — bilingual ministry application submit notifications (Facility Booking)
+# GRAPH_MAIL_SEND_ENABLED=false
+# GRAPH_MAIL_SENDER_MAILBOX=notifications@your-org.org
+# FACILITY_BOOKING_BASE_URL=http://localhost:5174

--- a/example.env
+++ b/example.env
@@ -50,3 +50,5 @@ JWT_SECRET_KEY=change-me-in-production
 # GRAPH_MAIL_SEND_ENABLED=false
 # GRAPH_MAIL_SENDER_MAILBOX=notifications@your-org.org
 # FACILITY_BOOKING_BASE_URL=http://localhost:5174
+# Non-prod only: redirect all ministry application mail here (comma-separated). Subject is prefixed with the real recipient.
+# GRAPH_MAIL_OVERRIDE_TO=dev@local.test

--- a/portal/application/org/ministry_application_mail_content.py
+++ b/portal/application/org/ministry_application_mail_content.py
@@ -1,0 +1,52 @@
+"""
+Bilingual ministry application submit email content (EN block first, then ZH).
+"""
+
+from uuid import UUID
+
+from portal.application.org.results import TranslationItemResult
+
+EN_LOCALE_ID = UUID("019dd0c8-69fa-7657-87bb-3b7255f5c5ae")
+ZH_TW_LOCALE_ID = UUID("019dd0c8-7540-7601-bfd1-7939ce75c16a")
+ZH_CN_LOCALE_ID = UUID("019dd0c8-7c12-727f-878f-16807adf39e8")
+
+
+def resolve_bilingual_ministry_names(translations: list[TranslationItemResult], fallback_name: str | None) -> tuple[str, str]:
+    """Return (english_name, chinese_name) from ministry translations."""
+    by_locale = {item.locale_id: item.name for item in translations if item.name}
+    fallback = (fallback_name or "Ministry Application").strip()
+    english_name = by_locale.get(EN_LOCALE_ID) or fallback
+    chinese_name = by_locale.get(ZH_TW_LOCALE_ID) or by_locale.get(ZH_CN_LOCALE_ID) or english_name
+    return english_name, chinese_name
+
+
+def build_applicant_submit_confirmation_html(*, ministry_name_en: str, ministry_name_zh: str, my_ministry_url: str) -> str:
+    return f"""<div>
+<p>Hello,</p>
+<p>Your ministry application for <strong>{_escape_html(ministry_name_en)}</strong> has been submitted and is pending approval.</p>
+<p><a href="{_escape_html(my_ministry_url)}">View My Ministry</a></p>
+<hr />
+<p>您好，</p>
+<p>您的事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」已成功提交，正在等待核准。</p>
+<p><a href="{_escape_html(my_ministry_url)}">查看我的事工</a></p>
+</div>"""
+
+
+def build_incumbent_notification_html(*, ministry_name_en: str, ministry_name_zh: str, applicant_display_name: str, approval_detail_url: str) -> str:
+    return f"""<div>
+<p>Hello,</p>
+<p><strong>{_escape_html(applicant_display_name)}</strong> submitted a ministry application for <strong>{_escape_html(ministry_name_en)}</strong>.</p>
+<p><a href="{_escape_html(approval_detail_url)}">Review application</a></p>
+<hr />
+<p>您好，</p>
+<p><strong>{_escape_html(applicant_display_name)}</strong> 提交了事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」。</p>
+<p><a href="{_escape_html(approval_detail_url)}">審核申請</a></p>
+</div>"""
+
+
+APPLICANT_SUBMIT_SUBJECT = "Ministry Application Submitted / 事工申請已提交"
+INCUMBENT_NOTIFICATION_SUBJECT = "Ministry Application Pending Your Approval / 事工申請待您核准"
+
+
+def _escape_html(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")

--- a/portal/application/org/ministry_application_mail_delivery.py
+++ b/portal/application/org/ministry_application_mail_delivery.py
@@ -1,0 +1,20 @@
+"""
+Resolve ministry application mail delivery targets for dev/test overrides.
+"""
+
+
+def resolve_mail_delivery_targets(*, intended_recipient: str, override_recipients: list[str]) -> tuple[list[str], str]:
+    """
+    Return recipient list and optional subject prefix.
+
+    When override_recipients is set, all mail is redirected there and the subject
+    is prefixed so the inbox shows the original intended recipient.
+    """
+    normalized_intended = (intended_recipient or "").strip()
+    if not normalized_intended:
+        return [], ""
+
+    overrides = [email.strip() for email in override_recipients if email and email.strip()]
+    if overrides:
+        return overrides, f"[DEV -> {normalized_intended}] "
+    return [normalized_intended], ""

--- a/portal/application/org/ministry_application_mail_service.py
+++ b/portal/application/org/ministry_application_mail_service.py
@@ -12,6 +12,7 @@ from portal.application.org.ministry_application_mail_content import (
     build_incumbent_notification_html,
     resolve_bilingual_ministry_names,
 )
+from portal.application.org.ministry_application_mail_delivery import resolve_mail_delivery_targets
 from portal.domain.org.ports import MailSendPort
 from portal.infrastructure.persistence.repositories.org.ministry_repository import MinistryRepository
 from portal.infrastructure.persistence.repositories.org.position_repository import PositionRepository
@@ -32,6 +33,7 @@ class MinistryApplicationMailService:
         *,
         facility_booking_base_url: str,
         enabled: bool,
+        override_recipients: list[str] | None = None,
     ):
         self._mail_send_port = mail_send_port
         self._ministry_repository = ministry_repository
@@ -39,6 +41,15 @@ class MinistryApplicationMailService:
         self._user_repository = user_repository
         self._facility_booking_base_url = facility_booking_base_url.rstrip("/")
         self._enabled = enabled
+        self._override_recipients = override_recipients or []
+
+    async def _deliver_html_mail(self, *, intended_recipient: str, subject: str, body_html: str) -> None:
+        recipients, subject_prefix = resolve_mail_delivery_targets(intended_recipient=intended_recipient, override_recipients=self._override_recipients)
+        if not recipients:
+            return
+        delivery_subject = f"{subject_prefix}{subject}"
+        for to_email in recipients:
+            await self._mail_send_port.send_html_mail(to_email=to_email, subject=delivery_subject, body_html=body_html)
 
     @distributed_trace()
     async def send_submit_notifications(self, *, ministry_id: UUID, owner_position_id: UUID, applicant_user_id: Optional[UUID]) -> None:
@@ -57,8 +68,8 @@ class MinistryApplicationMailService:
 
             applicant = await self._user_repository.get_sensitive_by_id(applicant_user_id) if applicant_user_id else None
             if applicant and applicant.email:
-                await self._mail_send_port.send_html_mail(
-                    to_email=applicant.email,
+                await self._deliver_html_mail(
+                    intended_recipient=applicant.email,
                     subject=APPLICANT_SUBMIT_SUBJECT,
                     body_html=build_applicant_submit_confirmation_html(
                         ministry_name_en=ministry_name_en, ministry_name_zh=ministry_name_zh, my_ministry_url=my_ministry_url
@@ -83,8 +94,8 @@ class MinistryApplicationMailService:
                 elif applicant and applicant.email:
                     applicant_display_name = applicant.email
 
-            await self._mail_send_port.send_html_mail(
-                to_email=incumbent.email,
+            await self._deliver_html_mail(
+                intended_recipient=incumbent.email,
                 subject=INCUMBENT_NOTIFICATION_SUBJECT,
                 body_html=build_incumbent_notification_html(
                     ministry_name_en=ministry_name_en,

--- a/portal/application/org/ministry_application_mail_service.py
+++ b/portal/application/org/ministry_application_mail_service.py
@@ -1,0 +1,97 @@
+"""
+Dispatch bilingual ministry application submit emails via MailSendPort.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from portal.application.org.ministry_application_mail_content import (
+    APPLICANT_SUBMIT_SUBJECT,
+    INCUMBENT_NOTIFICATION_SUBJECT,
+    build_applicant_submit_confirmation_html,
+    build_incumbent_notification_html,
+    resolve_bilingual_ministry_names,
+)
+from portal.domain.org.ports import MailSendPort
+from portal.infrastructure.persistence.repositories.org.ministry_repository import MinistryRepository
+from portal.infrastructure.persistence.repositories.org.position_repository import PositionRepository
+from portal.infrastructure.persistence.repositories.user_repository import UserRepository
+from portal.libs.logger import logger
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+
+class MinistryApplicationMailService:
+    """Send applicant and incumbent emails after ministry application submit."""
+
+    def __init__(
+        self,
+        mail_send_port: MailSendPort,
+        ministry_repository: MinistryRepository,
+        position_repository: PositionRepository,
+        user_repository: UserRepository,
+        *,
+        facility_booking_base_url: str,
+        enabled: bool,
+    ):
+        self._mail_send_port = mail_send_port
+        self._ministry_repository = ministry_repository
+        self._position_repository = position_repository
+        self._user_repository = user_repository
+        self._facility_booking_base_url = facility_booking_base_url.rstrip("/")
+        self._enabled = enabled
+
+    @distributed_trace()
+    async def send_submit_notifications(self, *, ministry_id: UUID, owner_position_id: UUID, applicant_user_id: Optional[UUID]) -> None:
+        if not self._enabled:
+            return
+
+        try:
+            ministry = await self._ministry_repository.get_by_id(ministry_id, all_locales=True)
+            if not ministry:
+                logger.warning("Skip ministry submit mail: ministry %s not found", ministry_id)
+                return
+
+            ministry_name_en, ministry_name_zh = resolve_bilingual_ministry_names(ministry.translations, ministry.name)
+            my_ministry_url = f"{self._facility_booking_base_url}/my-ministry"
+            approval_detail_url = f"{self._facility_booking_base_url}/my-ministry/approvals/{ministry_id}"
+
+            applicant = await self._user_repository.get_sensitive_by_id(applicant_user_id) if applicant_user_id else None
+            if applicant and applicant.email:
+                await self._mail_send_port.send_html_mail(
+                    to_email=applicant.email,
+                    subject=APPLICANT_SUBMIT_SUBJECT,
+                    body_html=build_applicant_submit_confirmation_html(
+                        ministry_name_en=ministry_name_en, ministry_name_zh=ministry_name_zh, my_ministry_url=my_ministry_url
+                    ),
+                )
+
+            incumbent_user_id = await self._position_repository.get_current_incumbent_user_id(owner_position_id)
+            if not incumbent_user_id:
+                logger.warning("Skip incumbent submit mail: position %s has no incumbent", owner_position_id)
+                return
+
+            incumbent = await self._user_repository.get_sensitive_by_id(incumbent_user_id)
+            if not incumbent or not incumbent.email:
+                logger.warning("Skip incumbent submit mail: incumbent user %s has no email", incumbent_user_id)
+                return
+
+            applicant_display_name = "Applicant"
+            if applicant_user_id:
+                applicant_profile = await self._user_repository.get_detail_by_id(applicant_user_id)
+                if applicant_profile and applicant_profile.preferred_name:
+                    applicant_display_name = applicant_profile.preferred_name
+                elif applicant and applicant.email:
+                    applicant_display_name = applicant.email
+
+            await self._mail_send_port.send_html_mail(
+                to_email=incumbent.email,
+                subject=INCUMBENT_NOTIFICATION_SUBJECT,
+                body_html=build_incumbent_notification_html(
+                    ministry_name_en=ministry_name_en,
+                    ministry_name_zh=ministry_name_zh,
+                    applicant_display_name=applicant_display_name,
+                    approval_detail_url=approval_detail_url,
+                ),
+            )
+        except Exception:
+            logger.exception("Failed to send ministry application submit emails for ministry %s", ministry_id)

--- a/portal/application/org/ministry_approval_service.py
+++ b/portal/application/org/ministry_approval_service.py
@@ -16,6 +16,7 @@ from portal.application.org.commands import (
     ReplaceMinistryMembersCommand,
     SubmitMinistryCommand,
 )
+from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
 from portal.application.org.ministry_service import MinistryService
 from portal.application.org.results import CreateIdResult, MinistryApprovalResult, MinistryPageResult
 from portal.domain.org.constants import MinistryApprovalStatus, MinistryStatus, OrgErrorCode
@@ -30,10 +31,17 @@ from portal.libs.tracing.distributed_trace import distributed_trace
 class MinistryApprovalService:
     """Ministry submission and approval workflow."""
 
-    def __init__(self, ministry_repository: MinistryRepository, ministry_service: MinistryService, position_repository: PositionRepository):
+    def __init__(
+        self,
+        ministry_repository: MinistryRepository,
+        ministry_service: MinistryService,
+        position_repository: PositionRepository,
+        ministry_application_mail_service: MinistryApplicationMailService | None = None,
+    ):
         self._repository = ministry_repository
         self._ministry_service = ministry_service
         self._position_repository = position_repository
+        self._ministry_application_mail_service = ministry_application_mail_service
         self._req_ctx: Optional[RequestContext] = get_request_context()
         self._user_ctx: Optional[UserContext] = get_user_context()
 
@@ -120,6 +128,10 @@ class MinistryApprovalService:
                 requested_by_id=user_id,
             )
         )
+        if self._ministry_application_mail_service:
+            await self._ministry_application_mail_service.send_submit_notifications(
+                ministry_id=ministry_id, owner_position_id=ministry.owner_position_id, applicant_user_id=user_id
+            )
 
     @distributed_trace()
     async def approve_ministry(self, ministry_id: UUID, command: ApproveMinistryCommand) -> None:

--- a/portal/config.py
+++ b/portal/config.py
@@ -117,6 +117,7 @@ class Configuration(BaseSettings):
     # [Microsoft Graph Mail.Send — ministry application notifications]
     GRAPH_MAIL_SEND_ENABLED: bool = Converter.to_bool(os.getenv(key="GRAPH_MAIL_SEND_ENABLED", default="false"), default=False)
     GRAPH_MAIL_SENDER_MAILBOX: Optional[str] = os.getenv(key="GRAPH_MAIL_SENDER_MAILBOX", default=None)
+    GRAPH_MAIL_OVERRIDE_TO: Optional[str] = os.getenv(key="GRAPH_MAIL_OVERRIDE_TO", default=None)
     FACILITY_BOOKING_BASE_URL: str = os.getenv(key="FACILITY_BOOKING_BASE_URL", default="http://localhost:5174")
 
     # [Member web apps — Origin -> app_code for /api/v1 auth]
@@ -182,6 +183,12 @@ class Configuration(BaseSettings):
     @property
     def is_dev(self) -> bool:
         return self.ENV.lower() not in ("prod", "stg")
+
+    def graph_mail_override_recipients(self) -> list[str]:
+        """Non-prod only: redirect ministry application mail to these addresses."""
+        if self.is_prod or not self.GRAPH_MAIL_OVERRIDE_TO:
+            return []
+        return [part.strip() for part in self.GRAPH_MAIL_OVERRIDE_TO.split(",") if part.strip()]
 
 
 @lru_cache()

--- a/portal/config.py
+++ b/portal/config.py
@@ -114,6 +114,11 @@ class Configuration(BaseSettings):
     AZURE_APP_CLIENT_SECRET: Optional[str] = os.getenv(key="AZURE_APP_CLIENT_SECRET", default=None)
     AZURE_ALLOWED_ISSUERS: Optional[str] = os.getenv(key="AZURE_ALLOWED_ISSUERS", default=None)
 
+    # [Microsoft Graph Mail.Send — ministry application notifications]
+    GRAPH_MAIL_SEND_ENABLED: bool = Converter.to_bool(os.getenv(key="GRAPH_MAIL_SEND_ENABLED", default="false"), default=False)
+    GRAPH_MAIL_SENDER_MAILBOX: Optional[str] = os.getenv(key="GRAPH_MAIL_SENDER_MAILBOX", default=None)
+    FACILITY_BOOKING_BASE_URL: str = os.getenv(key="FACILITY_BOOKING_BASE_URL", default="http://localhost:5174")
+
     # [Member web apps — Origin -> app_code for /api/v1 auth]
     # Format: code|origin|origin,code|origin
     # Example: facility-booking|http://localhost:5174,another-app|http://localhost:5180

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -7,6 +7,7 @@ from dependency_injector import containers, providers
 from portal.config import settings
 from portal.libs.database import PostgresConnection, RedisPool, Session
 from portal.libs.database.session_proxy import SessionProxy
+from portal.providers.graph_mail_provider import GraphMailProvider
 from portal.providers.jwt_provider import JWTProvider
 from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
 from portal.providers.microsoft_graph_provider import MicrosoftGraphProvider
@@ -38,3 +39,4 @@ class CoreContainer(containers.DeclarativeContainer):
 
     ms_graph = providers.Container(MSGraphContainer)
     microsoft_graph_provider = providers.Singleton(MicrosoftGraphProvider, users_factory=ms_graph.users.provider)
+    graph_mail_provider = providers.Singleton(GraphMailProvider, mail_factory=ms_graph.mail.provider)

--- a/portal/containers/org.py
+++ b/portal/containers/org.py
@@ -5,11 +5,13 @@ Organization bounded context DI container.
 from dependency_injector import containers, providers
 
 from portal.application.org.member_person_service import MemberPersonService
+from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
 from portal.application.org.ministry_approval_service import MinistryApprovalService
 from portal.application.org.ministry_catalog_service import MinistryCatalogService
 from portal.application.org.ministry_service import MinistryService
 from portal.application.org.org_user_search_service import OrgUserSearchService
 from portal.application.org.position_service import PositionService
+from portal.config import settings as app_settings
 from portal.infrastructure.persistence.repositories.member.person_repository import PersonRepository
 from portal.infrastructure.persistence.repositories.org.ministry_repository import MinistryRepository
 from portal.infrastructure.persistence.repositories.org.ministry_type_repository import MinistryTypeRepository
@@ -39,8 +41,21 @@ class OrgContainer(containers.DeclarativeContainer):
     ministry_catalog_service = providers.Factory(
         MinistryCatalogService, ministry_type_repository=ministry_type_repository, target_audience_repository=target_audience_repository
     )
+    ministry_application_mail_service = providers.Factory(
+        MinistryApplicationMailService,
+        mail_send_port=core.graph_mail_provider,
+        ministry_repository=ministry_repository,
+        position_repository=position_repository,
+        user_repository=user_repository,
+        facility_booking_base_url=app_settings.FACILITY_BOOKING_BASE_URL,
+        enabled=app_settings.GRAPH_MAIL_SEND_ENABLED,
+    )
     ministry_approval_service = providers.Factory(
-        MinistryApprovalService, ministry_repository=ministry_repository, ministry_service=ministry_service, position_repository=position_repository
+        MinistryApprovalService,
+        ministry_repository=ministry_repository,
+        ministry_service=ministry_service,
+        position_repository=position_repository,
+        ministry_application_mail_service=ministry_application_mail_service,
     )
     position_service = providers.Factory(PositionService, position_repository=position_repository)
     member_person_service = providers.Factory(MemberPersonService, person_repository=person_repository)

--- a/portal/containers/org.py
+++ b/portal/containers/org.py
@@ -49,6 +49,7 @@ class OrgContainer(containers.DeclarativeContainer):
         user_repository=user_repository,
         facility_booking_base_url=app_settings.FACILITY_BOOKING_BASE_URL,
         enabled=app_settings.GRAPH_MAIL_SEND_ENABLED,
+        override_recipients=app_settings.graph_mail_override_recipients(),
     )
     ministry_approval_service = providers.Factory(
         MinistryApprovalService,

--- a/portal/domain/org/ports.py
+++ b/portal/domain/org/ports.py
@@ -1,0 +1,11 @@
+"""
+Organization domain ports.
+"""
+
+from typing import Protocol
+
+
+class MailSendPort(Protocol):
+    """Send a single HTML email message."""
+
+    async def send_html_mail(self, *, to_email: str, subject: str, body_html: str) -> None: ...

--- a/portal/providers/graph_mail_provider.py
+++ b/portal/providers/graph_mail_provider.py
@@ -1,0 +1,22 @@
+"""
+Microsoft Graph mail send facade.
+"""
+
+from collections.abc import Callable
+
+from portal.providers.ms_graph.mail import MSGraphMail
+
+__all__ = ["GraphMailProvider"]
+
+
+class GraphMailProvider:
+    """Send HTML mail using app-only Graph Mail.Send."""
+
+    def __init__(self, mail_factory: Callable[[], MSGraphMail] = MSGraphMail) -> None:
+        self._mail_factory = mail_factory
+
+    def is_configured(self) -> bool:
+        return self._mail_factory().is_send_configured()
+
+    async def send_html_mail(self, *, to_email: str, subject: str, body_html: str) -> None:
+        await self._mail_factory().send_html_mail(to_email=to_email, subject=subject, body_html=body_html)

--- a/portal/providers/ms_graph/container.py
+++ b/portal/providers/ms_graph/container.py
@@ -4,6 +4,7 @@ MS Graph DI container.
 
 from dependency_injector import containers, providers
 
+from portal.providers.ms_graph.mail import MSGraphMail
 from portal.providers.ms_graph.users import MSGraphUsers
 
 
@@ -11,3 +12,4 @@ class MSGraphContainer(containers.DeclarativeContainer):
     """Microsoft Graph providers."""
 
     users = providers.Factory(MSGraphUsers)
+    mail = providers.Factory(MSGraphMail)

--- a/portal/providers/ms_graph/mail.py
+++ b/portal/providers/ms_graph/mail.py
@@ -1,0 +1,46 @@
+"""
+MSGraphMail — send mail via Microsoft Graph Mail.Send (application permission).
+"""
+
+from msgraph_beta.generated.models.body_type import BodyType
+from msgraph_beta.generated.models.email_address import EmailAddress
+from msgraph_beta.generated.models.item_body import ItemBody
+from msgraph_beta.generated.models.message import Message
+from msgraph_beta.generated.models.o_data_errors.o_data_error import ODataError
+from msgraph_beta.generated.models.recipient import Recipient
+from msgraph_beta.generated.users.item.send_mail.send_mail_post_request_body import SendMailPostRequestBody
+
+from portal.config import settings
+from portal.libs.logger import logger
+from portal.providers.ms_graph.base import MSGraphClientBase
+
+
+class MSGraphMail(MSGraphClientBase):
+    """Send HTML mail from a configured system mailbox."""
+
+    def is_send_configured(self) -> bool:
+        return self.is_configured() and bool(settings.GRAPH_MAIL_SENDER_MAILBOX)
+
+    async def send_html_mail(self, *, to_email: str, subject: str, body_html: str) -> None:
+        if not self.is_send_configured():
+            raise RuntimeError("Microsoft Graph mail send is not configured")
+        sender_mailbox = str(settings.GRAPH_MAIL_SENDER_MAILBOX).strip()
+        normalized_to = (to_email or "").strip()
+        if not normalized_to:
+            raise ValueError("Recipient email is required")
+
+        message = Message(
+            subject=subject,
+            body=ItemBody(content_type=BodyType.Html, content=body_html),
+            to_recipients=[Recipient(email_address=EmailAddress(address=normalized_to))],
+        )
+        request_body = SendMailPostRequestBody(message=message, save_to_sent_items=False)
+        try:
+            await self.client.users.by_user_id(sender_mailbox).send_mail.post(request_body)
+        except ODataError as exc:
+            logger.error(
+                "Graph send_mail failed: code=%s message=%s",
+                getattr(exc.error, "code", None) if getattr(exc, "error", None) else None,
+                getattr(exc.error, "message", None) if getattr(exc, "error", None) else str(exc),
+            )
+            raise

--- a/tests/application/org/test_ministry_application_mail_content.py
+++ b/tests/application/org/test_ministry_application_mail_content.py
@@ -1,0 +1,44 @@
+"""
+Tests for ministry application bilingual mail content.
+"""
+
+from uuid import uuid4
+
+from portal.application.org.ministry_application_mail_content import (
+    EN_LOCALE_ID,
+    ZH_TW_LOCALE_ID,
+    build_applicant_submit_confirmation_html,
+    build_incumbent_notification_html,
+    resolve_bilingual_ministry_names,
+)
+from portal.application.org.results import TranslationItemResult
+
+
+def test_resolve_bilingual_ministry_names_uses_locale_translations():
+    en_name = "Youth Ministry"
+    zh_name = "青年事工"
+    translations = [TranslationItemResult(locale_id=EN_LOCALE_ID, name=en_name), TranslationItemResult(locale_id=ZH_TW_LOCALE_ID, name=zh_name)]
+    english_name, chinese_name = resolve_bilingual_ministry_names(translations, fallback_name="Fallback")
+    assert english_name == en_name
+    assert chinese_name == zh_name
+
+
+def test_applicant_submit_confirmation_html_is_bilingual_en_then_zh():
+    html = build_applicant_submit_confirmation_html(
+        ministry_name_en="Badminton", ministry_name_zh="羽毛球", my_ministry_url="http://localhost:5174/my-ministry"
+    )
+    assert "Badminton" in html
+    assert "羽毛球" in html
+    assert html.index("Hello,") < html.index("您好")
+    assert "http://localhost:5174/my-ministry" in html
+
+
+def test_incumbent_notification_html_includes_approval_deep_link():
+    ministry_id = uuid4()
+    approval_url = f"http://localhost:5174/my-ministry/approvals/{ministry_id}"
+    html = build_incumbent_notification_html(
+        ministry_name_en="Badminton", ministry_name_zh="羽毛球", applicant_display_name="Jane Applicant", approval_detail_url=approval_url
+    )
+    assert approval_url in html
+    assert "Jane Applicant" in html
+    assert html.index("Review application") < html.index("審核申請")

--- a/tests/application/org/test_ministry_application_mail_delivery.py
+++ b/tests/application/org/test_ministry_application_mail_delivery.py
@@ -1,0 +1,23 @@
+"""
+Tests for ministry application mail delivery overrides.
+"""
+
+from portal.application.org.ministry_application_mail_delivery import resolve_mail_delivery_targets
+
+
+def test_resolve_mail_delivery_targets_uses_intended_recipient_by_default():
+    recipients, prefix = resolve_mail_delivery_targets(intended_recipient="applicant@example.com", override_recipients=[])
+    assert recipients == ["applicant@example.com"]
+    assert prefix == ""
+
+
+def test_resolve_mail_delivery_targets_redirects_to_override_recipients():
+    recipients, prefix = resolve_mail_delivery_targets(intended_recipient="incumbent@example.com", override_recipients=["dev@local.test", "qa@local.test"])
+    assert recipients == ["dev@local.test", "qa@local.test"]
+    assert prefix == "[DEV -> incumbent@example.com] "
+
+
+def test_resolve_mail_delivery_targets_skips_blank_intended_recipient():
+    recipients, prefix = resolve_mail_delivery_targets(intended_recipient="  ", override_recipients=["dev@local.test"])
+    assert recipients == []
+    assert prefix == ""

--- a/tests/application/org/test_ministry_application_mail_service.py
+++ b/tests/application/org/test_ministry_application_mail_service.py
@@ -1,0 +1,100 @@
+"""
+Tests for ministry application mail dispatch.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.application.auth.results import UserDetail, UserSensitive
+from portal.application.org.ministry_application_mail_content import EN_LOCALE_ID, ZH_TW_LOCALE_ID
+from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
+from portal.application.org.results import MinistryDetailResult, TranslationItemResult
+from portal.domain.org.constants import MinistryStatus
+from tests.fixtures.org.stubs import StubMinistryRepository, StubPositionRepository
+
+
+class StubMailSendPort:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def send_html_mail(self, *, to_email: str, subject: str, body_html: str) -> None:
+        self.calls.append({"to_email": to_email, "subject": subject, "body_html": body_html})
+
+
+class StubMailUserRepository:
+    def __init__(self, users: dict[UUID, UserSensitive], profiles: dict[UUID, UserDetail] | None = None):
+        self.users = users
+        self.profiles = profiles or {}
+
+    async def get_sensitive_by_id(self, user_id: UUID):
+        return self.users.get(user_id)
+
+    async def get_detail_by_id(self, user_id: UUID):
+        return self.profiles.get(user_id)
+
+
+@pytest.mark.asyncio
+async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    mail_port = StubMailSendPort()
+    ministry_stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(
+                id=ministry_id,
+                name="Fallback",
+                status=MinistryStatus.PENDING_APPROVAL.value,
+                owner_position_id=owner_position_id,
+                has_priority_booking=False,
+                is_active=True,
+                translations=[
+                    TranslationItemResult(locale_id=EN_LOCALE_ID, name="Badminton Club"),
+                    TranslationItemResult(locale_id=ZH_TW_LOCALE_ID, name="羽毛球社"),
+                ],
+            )
+        }
+    )
+    user_stub = StubMailUserRepository(
+        users={
+            applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+            incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+        },
+        profiles={applicant_user_id: UserDetail(id=applicant_user_id, email="applicant@example.com", preferred_name="Applicant Name")},
+    )
+    service = MinistryApplicationMailService(
+        mail_port,
+        ministry_stub,
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
+        user_stub,
+        facility_booking_base_url="http://localhost:5174",
+        enabled=True,
+    )
+
+    await service.send_submit_notifications(ministry_id=ministry_id, owner_position_id=owner_position_id, applicant_user_id=applicant_user_id)
+
+    assert len(mail_port.calls) == 2
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    incumbent_call = next(call for call in mail_port.calls if call["to_email"] == "incumbent@example.com")
+    assert "Badminton Club" in applicant_call["body_html"]
+    assert "羽毛球社" in applicant_call["body_html"]
+    assert "/my-ministry" in applicant_call["body_html"]
+    assert f"/my-ministry/approvals/{ministry_id}" in incumbent_call["body_html"]
+    assert "Applicant Name" in incumbent_call["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_send_submit_notifications_noop_when_disabled():
+    mail_port = StubMailSendPort()
+    service = MinistryApplicationMailService(
+        mail_port,
+        StubMinistryRepository(),
+        StubPositionRepository(),
+        StubMailUserRepository(users={}),
+        facility_booking_base_url="http://localhost:5174",
+        enabled=False,
+    )
+    await service.send_submit_notifications(ministry_id=uuid4(), owner_position_id=uuid4(), applicant_user_id=uuid4())
+    assert mail_port.calls == []

--- a/tests/application/org/test_ministry_application_mail_service.py
+++ b/tests/application/org/test_ministry_application_mail_service.py
@@ -86,6 +86,50 @@ async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
 
 
 @pytest.mark.asyncio
+async def test_send_submit_notifications_redirects_to_override_recipients():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    mail_port = StubMailSendPort()
+    ministry_stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(
+                id=ministry_id,
+                name="Badminton",
+                status=MinistryStatus.PENDING_APPROVAL.value,
+                owner_position_id=owner_position_id,
+                has_priority_booking=False,
+                is_active=True,
+            )
+        }
+    )
+    user_stub = StubMailUserRepository(
+        users={
+            applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+            incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+        }
+    )
+    service = MinistryApplicationMailService(
+        mail_port,
+        ministry_stub,
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
+        user_stub,
+        facility_booking_base_url="http://localhost:5174",
+        enabled=True,
+        override_recipients=["dev@local.test"],
+    )
+
+    await service.send_submit_notifications(ministry_id=ministry_id, owner_position_id=owner_position_id, applicant_user_id=applicant_user_id)
+
+    assert len(mail_port.calls) == 2
+    assert all(call["to_email"] == "dev@local.test" for call in mail_port.calls)
+    assert all(call["subject"].startswith("[DEV ->") for call in mail_port.calls)
+    assert any("[DEV -> applicant@example.com]" in call["subject"] for call in mail_port.calls)
+    assert any("[DEV -> incumbent@example.com]" in call["subject"] for call in mail_port.calls)
+
+
+@pytest.mark.asyncio
 async def test_send_submit_notifications_noop_when_disabled():
     mail_port = StubMailSendPort()
     service = MinistryApplicationMailService(

--- a/tests/application/org/test_ministry_services.py
+++ b/tests/application/org/test_ministry_services.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import ValidationError
 
+from portal.application.auth.results import UserSensitive
 from portal.application.org.commands import (
     CreateMinistryCommand,
     MinistryApplicationCommand,
@@ -20,11 +21,13 @@ from portal.application.org.commands import (
     StewardDirectoryQueryCommand,
     SubmitMinistryCommand,
 )
+from portal.application.org.ministry_application_mail_content import EN_LOCALE_ID
+from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
 from portal.application.org.ministry_approval_service import MinistryApprovalService
 from portal.application.org.ministry_schedule import validate_ministry_schedules
 from portal.application.org.ministry_service import MinistryService
 from portal.application.org.org_user_search_service import OrgUserSearchService
-from portal.application.org.results import MinistryDetailResult, MinistryMemberResult, OrgUserSearchItemResult, TargetAudienceResult
+from portal.application.org.results import MinistryDetailResult, MinistryMemberResult, OrgUserSearchItemResult, TargetAudienceResult, TranslationItemResult
 from portal.application.org.steward_directory_query import matches_steward_directory_q
 from portal.application.org.target_audience_validation import validate_target_audience_ids
 from portal.domain.facility.days_of_week_mask import days_to_mask, mask_to_days
@@ -32,6 +35,7 @@ from portal.domain.org.catalog_codes import TARGET_AUDIENCE_ADULTS, TARGET_AUDIE
 from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 from portal.exceptions.responses import BadRequestException, NotFoundException
 from portal.libs.contexts.user_context import UserContext
+from tests.application.org.test_ministry_application_mail_service import StubMailSendPort, StubMailUserRepository
 from tests.fixtures.org.stubs import (
     StubMinistryRepository,
     StubMinistryTypeRepository,
@@ -58,9 +62,13 @@ def make_approval_service(
     type_stub: StubMinistryTypeRepository | None = None,
     audience_stub: StubTargetAudienceRepository | None = None,
     position_stub: StubPositionRepository | None = None,
+    mail_service: MinistryApplicationMailService | None = None,
 ) -> MinistryApprovalService:
     return MinistryApprovalService(
-        ministry_stub, make_service(ministry_stub, type_stub=type_stub, audience_stub=audience_stub), position_stub or StubPositionRepository()
+        ministry_stub,
+        make_service(ministry_stub, type_stub=type_stub, audience_stub=audience_stub),
+        position_stub or StubPositionRepository(),
+        ministry_application_mail_service=mail_service,
     )
 
 
@@ -458,6 +466,56 @@ async def test_create_application_rejects_vacant_owner_position():
         )
     assert exc_info.value.error_code == "ORG_POSITION_NO_INCUMBENT"
     assert stub.insert_calls == []
+
+
+@pytest.mark.asyncio
+async def test_submit_ministry_dispatches_submit_mail_notifications():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(
+                id=ministry_id,
+                name="Badminton",
+                status=MinistryStatus.DRAFT.value,
+                owner_position_id=owner_position_id,
+                has_priority_booking=False,
+                is_active=True,
+                translations=[TranslationItemResult(locale_id=EN_LOCALE_ID, name="Badminton Club")],
+            )
+        },
+        members_by_ministry={
+            ministry_id: [
+                MinistryMemberResult(user_id=uuid4(), member_role=MinistryMemberRole.PRIMARY.value),
+                MinistryMemberResult(user_id=uuid4(), member_role=MinistryMemberRole.SECONDARY.value),
+            ]
+        },
+    )
+    mail_port = StubMailSendPort()
+    mail_service = MinistryApplicationMailService(
+        mail_port,
+        stub,
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
+        StubMailUserRepository(
+            users={
+                applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+                incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+            }
+        ),
+        facility_booking_base_url="http://localhost:5174",
+        enabled=True,
+    )
+    approval_service = make_approval_service(
+        stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
+    )
+    approval_service._user_ctx = UserContext(user_id=applicant_user_id, email="applicant@example.com", is_admin=False, is_superuser=False)
+
+    await approval_service.submit_ministry(ministry_id, SubmitMinistryCommand())
+
+    assert len(mail_port.calls) == 2
+    assert {call["to_email"] for call in mail_port.calls} == {"applicant@example.com", "incumbent@example.com"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_graph_mail_override_config.py
+++ b/tests/test_graph_mail_override_config.py
@@ -1,0 +1,19 @@
+"""
+Tests for graph mail override config.
+"""
+
+from portal.config import Configuration
+
+
+def test_graph_mail_override_recipients_parses_comma_separated_addresses(monkeypatch):
+    monkeypatch.setenv("ENV", "dev")
+    monkeypatch.setenv("GRAPH_MAIL_OVERRIDE_TO", " dev@local.test , qa@local.test ")
+    config = Configuration()
+    assert config.graph_mail_override_recipients() == ["dev@local.test", "qa@local.test"]
+
+
+def test_graph_mail_override_recipients_ignored_in_prod(monkeypatch):
+    monkeypatch.setenv("ENV", "prod")
+    monkeypatch.setenv("GRAPH_MAIL_OVERRIDE_TO", "dev@local.test")
+    config = Configuration()
+    assert config.graph_mail_override_recipients() == []


### PR DESCRIPTION
## Summary

- Add a send-only Microsoft Graph `Mail.Send` provider and dispatch two bilingual (EN then ZH) Outlook emails after a successful Ministry Application submit: applicant confirmation with My Ministry link, and Owner-position incumbent notification with `/my-ministry/approvals/{ministryId}` deep link.
- Wire mail dispatch through `MinistryApplicationMailService` from `MinistryApprovalService.submit_ministry`, with stub-based tests (no live Graph in CI).
- Document Entra `Mail.Send` setup in `README.md` and `example.env`.
- Add optional `GRAPH_MAIL_OVERRIDE_TO` (non-prod) to redirect dev/stg mail to safe inboxes; subject is prefixed with the intended recipient.

Closes #104

## Test plan

- [x] `uv run pytest tests/application/org/test_ministry_application_mail_content.py tests/application/org/test_ministry_application_mail_service.py tests/application/org/test_ministry_application_mail_delivery.py tests/application/org/test_ministry_services.py tests/test_graph_mail_override_config.py -v`
- [x] `uv run pytest`
- [x] `uv run ruff format` and `uv run ruff check --fix`
- [ ] Manual: set `GRAPH_MAIL_SEND_ENABLED=true`, `GRAPH_MAIL_SENDER_MAILBOX`, `FACILITY_BOOKING_BASE_URL`, and optional `GRAPH_MAIL_OVERRIDE_TO`; submit a Ministry Application from Facility Booking and verify both emails arrive with correct links


Made with [Cursor](https://cursor.com)