### PR TITLE
feat: Jinja ministry email templates and staff decision mail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,8 +116,16 @@ _Avoid_: applicant confirmation as the same email, using the incumbent's persona
 An Outlook message to the applicant right after submit, summarizing the Ministry Application and linking to My Ministry. Body is bilingual: English first, then Chinese.
 
 **Application decision email**:
-An Outlook message to the applicant when a Ministry Application is approved or rejected.
-_Avoid_: treating this as the incumbent notification
+An Outlook message to the applicant when a Ministry Application is approved or rejected. When the Owner-position incumbent decides via the member approval flow, the message reflects an incumbent decision. When church staff decide via the admin portal, the message names the staff member and states that the decision was made on the incumbent's behalf (staff acting for the Owner-position approver). The staff approver is also recorded on the Ministry row (`approved_by_id` / `rejected_by_id`) for audit.
+_Avoid_: treating this as the incumbent notification, using incumbent-only wording for a staff decision, exposing staff personal email in the body
+
+**Incumbent staff-decision notification email**:
+An Outlook message to the Owner-position incumbent when church staff approve or reject a Ministry Application via the admin portal. Names the staff member, states that staff acted on the incumbent's behalf, summarizes the outcome, and confirms no further action is required.
+_Avoid_: treating this as the pending Application notification email, asking the incumbent to approve again after staff already decided
+
+**Application summary (email)**:
+A structured block in ministry application emails listing key facts about the Ministry Application (for example ministry type, applicant, submitted date). Distinct from the free-form rejection reason on decline.
+_Avoid_: duplicating the full admin approval page, treating summary as a separate aggregate
 
 **Assignable Owner position**:
 An org position with `can_own_ministry` and a current incumbent. Booking create lists only these positions; submit is blocked if the chosen position has no incumbent.

--- a/docs/adr/0013-ministry-email-jinja-templates-and-staff-decision-mail.md
+++ b/docs/adr/0013-ministry-email-jinja-templates-and-staff-decision-mail.md
@@ -1,0 +1,25 @@
+# Ministry application email templates (Jinja2) and staff decision notifications
+
+ADR 0012 established Graph `Mail.Send`, bilingual EN-then-ZH bodies, and incumbent-only member approval. Ministry application emails still render as inline Python f-strings with minimal HTML. We replace that with **version-controlled Jinja2 templates** under `portal/templates/email/`, a reusable **`EmailTemplateRenderPort`** (application depends on the port; `TemplateRenderProvider` implements Jinja2 async), and Facility Booking **inline CSS** branding (Figma tokens: `#1e283f`, `#1865d8`, `#fab148`, `#e9f3f5`; text header in v1, no logo URL). Bilingual stacking and Graph transport are unchanged.
+
+**Admin portal decisions** now send mail: an **Application decision email** to the applicant (`decision_channel=staff`) naming the staff member and stating they acted **on the Owner-position incumbent's behalf**; and an **Incumbent staff-decision notification email** to the current Owner incumbent (outcome summary, no further action). **Incumbent member decisions** keep the incumbent-channel decision email only. **`decision_channel`** is passed on approve/reject commands; `MinistryApprovalService` triggers mail inside approve/reject when a channel is set (member wrapper passes `incumbent`, admin router passes `staff`).
+
+**Application summary** (ministry type, applicant, submitted_at in `America/Toronto`, target audiences, primary steward) appears only on the **Application notification email** (incumbent pending), not on submit confirmation or decision emails.
+
+## Considered Options
+
+- **Keep f-string builders** — rejected: hard to design review, no shared layout, blocks reuse for future mail types.
+- **DB-editable templates (admin CMS)** — rejected for v1: deploy-reviewed files are enough; avoids schema and RBAC for template editing.
+- **SMTP + Jinja like conf-portal-api** — rejected: this repo already committed to Graph in ADR 0012; only the render pattern is borrowed.
+- **Single-language by recipient locale** — rejected: church policy remains bilingual stacking (ADR 0012).
+- **Staff decision email without incumbent follow-up** — rejected: product wants the Owner incumbent informed when staff decide on their behalf (Q17).
+- **Staff decision copy without naming the staff member** — rejected: audit stays on `approved_by_id` / `rejected_by_id`, but the body names the staff member while framing the act as on the incumbent's behalf.
+
+## Consequences
+
+- Add `jinja2` dependency; new `portal/templates/email/` tree (`base.html`, partials, four ministry templates including `incumbent_staff_decision_notification.html`).
+- `MinistryApplicationMailService` builds template context (summary, bilingual names, links) and renders via port; retire f-string HTML in `ministry_application_mail_content.py` (subjects and context helpers may remain or move adjacent).
+- Extend `ApproveMinistryCommand` / `RejectMinistryCommand` with optional `decision_channel`; admin ministry approve/reject routes pass `staff`.
+- Tests: render snapshots or keyword assertions on HTML; mail service fakes assert applicant + incumbent sends on admin decision.
+- `CONTEXT.md` glossary updated: Application decision email, Application summary (email), Incumbent staff-decision notification email.
+- Out of scope for this ADR: plaintext multipart, mail queue/retry, per-recipient locale, hosted logo config, template preview API.

--- a/portal/application/org/commands.py
+++ b/portal/application/org/commands.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, model_validator
 
 from portal.application.rbac.commands import BulkIdsCommand, DeleteCommand, PagesQueryCommand
-from portal.domain.org.constants import MinistryMemberRole, MinistryStatus, PositionOffice, PositionTeam
+from portal.domain.org.constants import MinistryDecisionChannel, MinistryMemberRole, MinistryStatus, PositionOffice, PositionTeam
 
 __all__ = [
     "ApproveMinistryCommand",
@@ -130,6 +130,7 @@ class ApproveMinistryCommand(BaseModel):
     """Approve pending ministry."""
 
     comment: Optional[str] = Field(default=None)
+    decision_channel: Optional[MinistryDecisionChannel] = Field(default=None)
 
 
 class RejectMinistryCommand(BaseModel):
@@ -137,6 +138,7 @@ class RejectMinistryCommand(BaseModel):
 
     rejection_reason: str = Field(...)
     comment: Optional[str] = Field(default=None)
+    decision_channel: Optional[MinistryDecisionChannel] = Field(default=None)
 
 
 class UpdateRejectedMinistryApplicationCommand(BaseModel):

--- a/portal/application/org/mappers.py
+++ b/portal/application/org/mappers.py
@@ -50,6 +50,7 @@ from portal.application.org.results import (
     TranslationItemResult,
 )
 from portal.domain.common.mixins import UUIDBaseModel
+from portal.domain.org.constants import MinistryDecisionChannel
 from portal.serializers.admin.v1.ministry import (
     AdminMinistryApplicationCreate,
     AdminMinistryApprove,
@@ -254,11 +255,11 @@ def replace_ministry_members_to_command(model: AdminMinistryReplaceMembers) -> R
 
 
 def approve_ministry_to_command(model: AdminMinistryApprove) -> ApproveMinistryCommand:
-    return ApproveMinistryCommand(comment=model.comment)
+    return ApproveMinistryCommand(comment=model.comment, decision_channel=MinistryDecisionChannel.STAFF)
 
 
 def reject_ministry_to_command(model: AdminMinistryReject) -> RejectMinistryCommand:
-    return RejectMinistryCommand(rejection_reason=model.rejection_reason, comment=model.comment)
+    return RejectMinistryCommand(rejection_reason=model.rejection_reason, comment=model.comment, decision_channel=MinistryDecisionChannel.STAFF)
 
 
 def ministry_detail_to_api(result: MinistryDetailResult) -> AdminMinistryDetail:

--- a/portal/application/org/ministry_application_mail_content.py
+++ b/portal/application/org/ministry_application_mail_content.py
@@ -1,14 +1,44 @@
 """
-Bilingual ministry application submit email content (EN block first, then ZH).
+Bilingual ministry application email subjects and template context helpers.
 """
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
-from portal.application.org.results import TranslationItemResult
+from portal.application.org.results import MinistryDetailResult, TranslationItemResult
+from portal.domain.org.constants import MinistryMemberRole
 
 EN_LOCALE_ID = UUID("019dd0c8-69fa-7657-87bb-3b7255f5c5ae")
 ZH_TW_LOCALE_ID = UUID("019dd0c8-7540-7601-bfd1-7939ce75c16a")
 ZH_CN_LOCALE_ID = UUID("019dd0c8-7c12-727f-878f-16807adf39e8")
+
+TORONTO_TZ = ZoneInfo("America/Toronto")
+
+APPLICANT_SUBMIT_SUBJECT = "Ministry Application Submitted / 事工申請已提交"
+INCUMBENT_NOTIFICATION_SUBJECT = "Ministry Application Pending Your Approval / 事工申請待您核准"
+APPLICANT_APPROVED_SUBJECT = "Ministry Application Approved / 事工申請已核准"
+APPLICANT_REJECTED_SUBJECT = "Ministry Application Declined / 事工申請未通過"
+INCUMBENT_STAFF_DECISION_SUBJECT = "Ministry Application Decision on Your Behalf / 事工申請代為決定通知"
+
+TEMPLATE_APPLICANT_SUBMIT_CONFIRMATION = "email/ministry/applicant_submit_confirmation.html"
+TEMPLATE_INCUMBENT_NOTIFICATION = "email/ministry/incumbent_notification.html"
+TEMPLATE_APPLICANT_DECISION_APPROVED = "email/ministry/applicant_decision_approved.html"
+TEMPLATE_APPLICANT_DECISION_REJECTED = "email/ministry/applicant_decision_rejected.html"
+TEMPLATE_INCUMBENT_STAFF_DECISION_NOTIFICATION = "email/ministry/incumbent_staff_decision_notification.html"
+
+
+@dataclass(frozen=True)
+class ApplicationSummaryContext:
+    """Structured application summary for incumbent notification email."""
+
+    ministry_type_name: str
+    applicant_display_name: str
+    submitted_at_display: str
+    target_audience_names: str
+    primary_steward_display_name: str
 
 
 def resolve_bilingual_ministry_names(translations: list[TranslationItemResult], fallback_name: str | None) -> tuple[str, str]:
@@ -20,61 +50,49 @@ def resolve_bilingual_ministry_names(translations: list[TranslationItemResult], 
     return english_name, chinese_name
 
 
-def build_applicant_submit_confirmation_html(*, ministry_name_en: str, ministry_name_zh: str, my_ministry_url: str) -> str:
-    return f"""<div>
-<p>Hello,</p>
-<p>Your ministry application for <strong>{_escape_html(ministry_name_en)}</strong> has been submitted and is pending approval.</p>
-<p><a href="{_escape_html(my_ministry_url)}">View My Ministry</a></p>
-<hr />
-<p>您好，</p>
-<p>您的事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」已成功提交，正在等待核准。</p>
-<p><a href="{_escape_html(my_ministry_url)}">查看我的事工</a></p>
-</div>"""
+def format_submitted_at_toronto(submitted_at: Optional[datetime]) -> str:
+    """Format submitted_at in America/Toronto for email display."""
+    if submitted_at is None:
+        return "—"
+    aware = submitted_at if submitted_at.tzinfo is not None else submitted_at.replace(tzinfo=timezone.utc)
+    local = aware.astimezone(TORONTO_TZ)
+    return local.strftime("%Y-%m-%d %H:%M %Z")
 
 
-def build_incumbent_notification_html(*, ministry_name_en: str, ministry_name_zh: str, applicant_display_name: str, approval_detail_url: str) -> str:
-    return f"""<div>
-<p>Hello,</p>
-<p><strong>{_escape_html(applicant_display_name)}</strong> submitted a ministry application for <strong>{_escape_html(ministry_name_en)}</strong>.</p>
-<p><a href="{_escape_html(approval_detail_url)}">Review application</a></p>
-<hr />
-<p>您好，</p>
-<p><strong>{_escape_html(applicant_display_name)}</strong> 提交了事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」。</p>
-<p><a href="{_escape_html(approval_detail_url)}">審核申請</a></p>
-</div>"""
+def build_application_summary_context(*, ministry: MinistryDetailResult, applicant_display_name: str) -> ApplicationSummaryContext:
+    """Build application summary block for incumbent notification email."""
+    ministry_type_name = ministry.ministry_type_name or ministry.ministry_type_code or "—"
+    audience_names = [item.name or item.code for item in ministry.target_audiences if item.name or item.code]
+    target_audience_names = ", ".join(audience_names) if audience_names else "—"
+    primary_steward = next((member for member in ministry.members if member.member_role == MinistryMemberRole.PRIMARY.value), None)
+    primary_steward_display_name = "—"
+    if primary_steward:
+        primary_steward_display_name = primary_steward.display_name or primary_steward.email or "—"
+    return ApplicationSummaryContext(
+        ministry_type_name=ministry_type_name,
+        applicant_display_name=applicant_display_name,
+        submitted_at_display=format_submitted_at_toronto(ministry.submitted_at),
+        target_audience_names=target_audience_names,
+        primary_steward_display_name=primary_steward_display_name,
+    )
 
 
-APPLICANT_SUBMIT_SUBJECT = "Ministry Application Submitted / 事工申請已提交"
-INCUMBENT_NOTIFICATION_SUBJECT = "Ministry Application Pending Your Approval / 事工申請待您核准"
-APPLICANT_APPROVED_SUBJECT = "Ministry Application Approved / 事工申請已核准"
-APPLICANT_REJECTED_SUBJECT = "Ministry Application Declined / 事工申請未通過"
+async def resolve_user_display_name(user_repository, user_id: Optional[UUID], *, fallback: str = "Applicant") -> str:
+    """Resolve a user-facing display name from profile or email."""
+    if not user_id:
+        return fallback
+    profile = await user_repository.get_detail_by_id(user_id)
+    if profile and profile.preferred_name:
+        return profile.preferred_name
+    sensitive = await user_repository.get_sensitive_by_id(user_id)
+    if sensitive and sensitive.email:
+        return sensitive.email
+    return fallback
 
 
-def build_applicant_approved_html(*, ministry_name_en: str, ministry_name_zh: str, my_ministry_url: str) -> str:
-    return f"""<div>
-<p>Hello,</p>
-<p>Your ministry application for <strong>{_escape_html(ministry_name_en)}</strong> has been approved.</p>
-<p><a href="{_escape_html(my_ministry_url)}">View My Ministry</a></p>
-<hr />
-<p>您好，</p>
-<p>您的事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」已獲核准。</p>
-<p><a href="{_escape_html(my_ministry_url)}">查看我的事工</a></p>
-</div>"""
-
-
-def build_applicant_rejected_html(*, ministry_name_en: str, ministry_name_zh: str, rejection_reason: str, my_ministry_url: str) -> str:
-    return f"""<div>
-<p>Hello,</p>
-<p>Your ministry application for <strong>{_escape_html(ministry_name_en)}</strong> was not approved.</p>
-<p>Reason: {_escape_html(rejection_reason)}</p>
-<p><a href="{_escape_html(my_ministry_url)}">View My Ministry</a></p>
-<hr />
-<p>您好，</p>
-<p>您的事工申請「<strong>{_escape_html(ministry_name_zh)}</strong>」未獲核准。</p>
-<p>原因：{_escape_html(rejection_reason)}</p>
-<p><a href="{_escape_html(my_ministry_url)}">查看我的事工</a></p>
-</div>"""
-
-
-def _escape_html(value: str) -> str:
-    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
+async def resolve_staff_display_name(user_repository, user_id: UUID) -> str:
+    """Resolve staff name for email copy without exposing personal email."""
+    profile = await user_repository.get_detail_by_id(user_id)
+    if profile and profile.preferred_name:
+        return profile.preferred_name
+    return "Church staff"

--- a/portal/application/org/ministry_application_mail_service.py
+++ b/portal/application/org/ministry_application_mail_service.py
@@ -1,5 +1,5 @@
 """
-Dispatch bilingual ministry application submit emails via MailSendPort.
+Dispatch bilingual ministry application emails via MailSendPort.
 """
 
 from typing import Optional
@@ -10,13 +10,20 @@ from portal.application.org.ministry_application_mail_content import (
     APPLICANT_REJECTED_SUBJECT,
     APPLICANT_SUBMIT_SUBJECT,
     INCUMBENT_NOTIFICATION_SUBJECT,
-    build_applicant_approved_html,
-    build_applicant_rejected_html,
-    build_applicant_submit_confirmation_html,
-    build_incumbent_notification_html,
+    INCUMBENT_STAFF_DECISION_SUBJECT,
+    TEMPLATE_APPLICANT_DECISION_APPROVED,
+    TEMPLATE_APPLICANT_DECISION_REJECTED,
+    TEMPLATE_APPLICANT_SUBMIT_CONFIRMATION,
+    TEMPLATE_INCUMBENT_NOTIFICATION,
+    TEMPLATE_INCUMBENT_STAFF_DECISION_NOTIFICATION,
+    build_application_summary_context,
     resolve_bilingual_ministry_names,
+    resolve_staff_display_name,
+    resolve_user_display_name,
 )
 from portal.application.org.ministry_application_mail_delivery import resolve_mail_delivery_targets
+from portal.domain.email.ports import EmailTemplateRenderPort
+from portal.domain.org.constants import MinistryDecisionChannel
 from portal.domain.org.ports import MailSendPort
 from portal.infrastructure.persistence.repositories.org.ministry_repository import MinistryRepository
 from portal.infrastructure.persistence.repositories.org.position_repository import PositionRepository
@@ -26,11 +33,12 @@ from portal.libs.tracing.distributed_trace import distributed_trace
 
 
 class MinistryApplicationMailService:
-    """Send applicant and incumbent emails after ministry application submit."""
+    """Send applicant and incumbent emails for ministry application workflow."""
 
     def __init__(
         self,
         mail_send_port: MailSendPort,
+        email_template_render_port: EmailTemplateRenderPort,
         ministry_repository: MinistryRepository,
         position_repository: PositionRepository,
         user_repository: UserRepository,
@@ -40,6 +48,7 @@ class MinistryApplicationMailService:
         override_recipients: list[str] | None = None,
     ):
         self._mail_send_port = mail_send_port
+        self._email_template_render_port = email_template_render_port
         self._ministry_repository = ministry_repository
         self._position_repository = position_repository
         self._user_repository = user_repository
@@ -54,6 +63,9 @@ class MinistryApplicationMailService:
         delivery_subject = f"{subject_prefix}{subject}"
         for to_email in recipients:
             await self._mail_send_port.send_html_mail(to_email=to_email, subject=delivery_subject, body_html=body_html)
+
+    async def _render(self, template_name: str, **context: object) -> str:
+        return await self._email_template_render_port.render_email_template(template_name, **context)
 
     @distributed_trace()
     async def send_submit_notifications(self, *, ministry_id: UUID, owner_position_id: UUID, applicant_user_id: Optional[UUID]) -> None:
@@ -72,13 +84,13 @@ class MinistryApplicationMailService:
 
             applicant = await self._user_repository.get_sensitive_by_id(applicant_user_id) if applicant_user_id else None
             if applicant and applicant.email:
-                await self._deliver_html_mail(
-                    intended_recipient=applicant.email,
-                    subject=APPLICANT_SUBMIT_SUBJECT,
-                    body_html=build_applicant_submit_confirmation_html(
-                        ministry_name_en=ministry_name_en, ministry_name_zh=ministry_name_zh, my_ministry_url=my_ministry_url
-                    ),
+                body_html = await self._render(
+                    TEMPLATE_APPLICANT_SUBMIT_CONFIRMATION,
+                    ministry_name_en=ministry_name_en,
+                    ministry_name_zh=ministry_name_zh,
+                    my_ministry_url=my_ministry_url,
                 )
+                await self._deliver_html_mail(intended_recipient=applicant.email, subject=APPLICANT_SUBMIT_SUBJECT, body_html=body_html)
 
             incumbent_user_id = await self._position_repository.get_current_incumbent_user_id(owner_position_id)
             if not incumbent_user_id:
@@ -90,30 +102,31 @@ class MinistryApplicationMailService:
                 logger.warning("Skip incumbent submit mail: incumbent user %s has no email", incumbent_user_id)
                 return
 
-            applicant_display_name = "Applicant"
-            if applicant_user_id:
-                applicant_profile = await self._user_repository.get_detail_by_id(applicant_user_id)
-                if applicant_profile and applicant_profile.preferred_name:
-                    applicant_display_name = applicant_profile.preferred_name
-                elif applicant and applicant.email:
-                    applicant_display_name = applicant.email
-
-            await self._deliver_html_mail(
-                intended_recipient=incumbent.email,
-                subject=INCUMBENT_NOTIFICATION_SUBJECT,
-                body_html=build_incumbent_notification_html(
-                    ministry_name_en=ministry_name_en,
-                    ministry_name_zh=ministry_name_zh,
-                    applicant_display_name=applicant_display_name,
-                    approval_detail_url=approval_detail_url,
-                ),
+            applicant_display_name = await resolve_user_display_name(self._user_repository, applicant_user_id)
+            application_summary = build_application_summary_context(ministry=ministry, applicant_display_name=applicant_display_name)
+            body_html = await self._render(
+                TEMPLATE_INCUMBENT_NOTIFICATION,
+                ministry_name_en=ministry_name_en,
+                ministry_name_zh=ministry_name_zh,
+                applicant_display_name=applicant_display_name,
+                approval_detail_url=approval_detail_url,
+                application_summary=application_summary,
             )
+            await self._deliver_html_mail(intended_recipient=incumbent.email, subject=INCUMBENT_NOTIFICATION_SUBJECT, body_html=body_html)
         except Exception:
             logger.exception("Failed to send ministry application submit emails for ministry %s", ministry_id)
 
     @distributed_trace()
     async def send_decision_notification(
-        self, *, ministry_id: UUID, applicant_user_id: Optional[UUID], approved: bool, rejection_reason: Optional[str] = None
+        self,
+        *,
+        ministry_id: UUID,
+        applicant_user_id: Optional[UUID],
+        approved: bool,
+        decision_channel: MinistryDecisionChannel,
+        decided_by_user_id: UUID,
+        owner_position_id: UUID,
+        rejection_reason: Optional[str] = None,
     ) -> None:
         if not self._enabled:
             return
@@ -136,16 +149,63 @@ class MinistryApplicationMailService:
 
             ministry_name_en, ministry_name_zh = resolve_bilingual_ministry_names(ministry.translations, ministry.name)
             my_ministry_url = f"{self._facility_booking_base_url}/my-ministry"
+            channel_value = decision_channel.value
+            staff_display_name: Optional[str] = None
+            incumbent_display_name: Optional[str] = None
+
+            if decision_channel == MinistryDecisionChannel.STAFF:
+                staff_display_name = await resolve_staff_display_name(self._user_repository, decided_by_user_id)
+                incumbent_user_id = await self._position_repository.get_current_incumbent_user_id(owner_position_id)
+                incumbent_display_name = await resolve_user_display_name(self._user_repository, incumbent_user_id, fallback="Owner incumbent")
+
             if approved:
                 subject = APPLICANT_APPROVED_SUBJECT
-                body_html = build_applicant_approved_html(ministry_name_en=ministry_name_en, ministry_name_zh=ministry_name_zh, my_ministry_url=my_ministry_url)
+                template_name = TEMPLATE_APPLICANT_DECISION_APPROVED
+                template_context: dict[str, object] = {
+                    "ministry_name_en": ministry_name_en,
+                    "ministry_name_zh": ministry_name_zh,
+                    "my_ministry_url": my_ministry_url,
+                    "decision_channel": channel_value,
+                    "staff_display_name": staff_display_name,
+                    "incumbent_display_name": incumbent_display_name,
+                }
             else:
                 reason = (rejection_reason or ministry.rejection_reason or "No reason provided").strip()
                 subject = APPLICANT_REJECTED_SUBJECT
-                body_html = build_applicant_rejected_html(
-                    ministry_name_en=ministry_name_en, ministry_name_zh=ministry_name_zh, rejection_reason=reason, my_ministry_url=my_ministry_url
-                )
+                template_name = TEMPLATE_APPLICANT_DECISION_REJECTED
+                template_context = {
+                    "ministry_name_en": ministry_name_en,
+                    "ministry_name_zh": ministry_name_zh,
+                    "my_ministry_url": my_ministry_url,
+                    "rejection_reason": reason,
+                    "decision_channel": channel_value,
+                    "staff_display_name": staff_display_name,
+                    "incumbent_display_name": incumbent_display_name,
+                }
 
+            body_html = await self._render(template_name, **template_context)
             await self._deliver_html_mail(intended_recipient=applicant.email, subject=subject, body_html=body_html)
+
+            if decision_channel != MinistryDecisionChannel.STAFF:
+                return
+
+            incumbent_user_id = await self._position_repository.get_current_incumbent_user_id(owner_position_id)
+            if not incumbent_user_id:
+                logger.warning("Skip incumbent staff-decision mail: position %s has no incumbent", owner_position_id)
+                return
+            incumbent = await self._user_repository.get_sensitive_by_id(incumbent_user_id)
+            if not incumbent or not incumbent.email:
+                logger.warning("Skip incumbent staff-decision mail: incumbent user %s has no email", incumbent_user_id)
+                return
+
+            staff_body_html = await self._render(
+                TEMPLATE_INCUMBENT_STAFF_DECISION_NOTIFICATION,
+                ministry_name_en=ministry_name_en,
+                ministry_name_zh=ministry_name_zh,
+                staff_display_name=staff_display_name,
+                approved=approved,
+                rejection_reason=template_context.get("rejection_reason"),
+            )
+            await self._deliver_html_mail(intended_recipient=incumbent.email, subject=INCUMBENT_STAFF_DECISION_SUBJECT, body_html=staff_body_html)
         except Exception:
             logger.exception("Failed to send ministry application decision email for ministry %s", ministry_id)

--- a/portal/application/org/ministry_approval_service.py
+++ b/portal/application/org/ministry_approval_service.py
@@ -21,7 +21,7 @@ from portal.application.org.commands import (
 from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
 from portal.application.org.ministry_service import MinistryService
 from portal.application.org.results import CreateIdResult, MinistryApprovalResult, MinistryDetailResult, MinistryListResult, MinistryPageResult
-from portal.domain.org.constants import MinistryApprovalStatus, MinistryStatus, OrgErrorCode
+from portal.domain.org.constants import MinistryApprovalStatus, MinistryDecisionChannel, MinistryStatus, OrgErrorCode
 from portal.exceptions.responses import BadRequestException, ForbiddenException, NotFoundException
 from portal.infrastructure.persistence.repositories.org.ministry_repository import MinistryRepository
 from portal.infrastructure.persistence.repositories.org.position_repository import PositionRepository
@@ -195,6 +195,15 @@ class MinistryApprovalService:
         await self._repository.update_approval(
             ministry_id=ministry_id, status=MinistryApprovalStatus.APPROVED.value, resolved_by_id=user_id, decided_at=now, comment=command.comment
         )
+        if self._ministry_application_mail_service and command.decision_channel and user_id and ministry.owner_position_id:
+            await self._ministry_application_mail_service.send_decision_notification(
+                ministry_id=ministry_id,
+                applicant_user_id=ministry.submitted_by_id,
+                approved=True,
+                decision_channel=command.decision_channel,
+                decided_by_user_id=user_id,
+                owner_position_id=ministry.owner_position_id,
+            )
 
     @distributed_trace()
     async def reject_ministry(self, ministry_id: UUID, command: RejectMinistryCommand) -> None:
@@ -220,6 +229,16 @@ class MinistryApprovalService:
             decided_at=now,
             comment=command.comment or command.rejection_reason,
         )
+        if self._ministry_application_mail_service and command.decision_channel and user_id and ministry.owner_position_id:
+            await self._ministry_application_mail_service.send_decision_notification(
+                ministry_id=ministry_id,
+                applicant_user_id=ministry.submitted_by_id,
+                approved=False,
+                decision_channel=command.decision_channel,
+                decided_by_user_id=user_id,
+                owner_position_id=ministry.owner_position_id,
+                rejection_reason=command.rejection_reason,
+            )
 
     @distributed_trace()
     async def list_pending_for_incumbent(self) -> MinistryListResult:
@@ -241,11 +260,8 @@ class MinistryApprovalService:
         if not ministry:
             raise self._ministry_not_found(ministry_id)
         await self._require_incumbent(ministry)
-        await self.approve_ministry(ministry_id, command)
-        if self._ministry_application_mail_service:
-            await self._ministry_application_mail_service.send_decision_notification(
-                ministry_id=ministry_id, applicant_user_id=ministry.submitted_by_id, approved=True
-            )
+        command_with_channel = command.model_copy(update={"decision_channel": MinistryDecisionChannel.INCUMBENT})
+        await self.approve_ministry(ministry_id, command_with_channel)
 
     @distributed_trace()
     async def reject_ministry_as_incumbent(self, ministry_id: UUID, command: RejectMinistryCommand) -> None:
@@ -253,11 +269,8 @@ class MinistryApprovalService:
         if not ministry:
             raise self._ministry_not_found(ministry_id)
         await self._require_incumbent(ministry)
-        await self.reject_ministry(ministry_id, command)
-        if self._ministry_application_mail_service:
-            await self._ministry_application_mail_service.send_decision_notification(
-                ministry_id=ministry_id, applicant_user_id=ministry.submitted_by_id, approved=False, rejection_reason=command.rejection_reason
-            )
+        command_with_channel = command.model_copy(update={"decision_channel": MinistryDecisionChannel.INCUMBENT})
+        await self.reject_ministry(ministry_id, command_with_channel)
 
     @distributed_trace()
     async def update_rejected_application(self, ministry_id: UUID, command: UpdateRejectedMinistryApplicationCommand) -> None:

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -15,6 +15,7 @@ from portal.providers.microsoft_oidc_provider import MicrosoftOidcProvider
 from portal.providers.ms_graph.container import MSGraphContainer
 from portal.providers.password_provider import PasswordProvider
 from portal.providers.refresh_token_provider import RefreshTokenProvider
+from portal.providers.template_render_provider import TemplateRenderProvider
 from portal.providers.token_blacklist_provider import TokenBlacklistProvider
 
 
@@ -40,3 +41,4 @@ class CoreContainer(containers.DeclarativeContainer):
     ms_graph = providers.Container(MSGraphContainer)
     microsoft_graph_provider = providers.Singleton(MicrosoftGraphProvider, users_factory=ms_graph.users.provider)
     graph_mail_provider = providers.Singleton(GraphMailProvider, mail_factory=ms_graph.mail.provider)
+    email_template_render_provider = providers.Singleton(TemplateRenderProvider)

--- a/portal/containers/org.py
+++ b/portal/containers/org.py
@@ -44,6 +44,7 @@ class OrgContainer(containers.DeclarativeContainer):
     ministry_application_mail_service = providers.Factory(
         MinistryApplicationMailService,
         mail_send_port=core.graph_mail_provider,
+        email_template_render_port=core.email_template_render_provider,
         ministry_repository=ministry_repository,
         position_repository=position_repository,
         user_repository=user_repository,

--- a/portal/domain/email/ports.py
+++ b/portal/domain/email/ports.py
@@ -1,0 +1,11 @@
+"""
+Email rendering domain ports.
+"""
+
+from typing import Protocol
+
+
+class EmailTemplateRenderPort(Protocol):
+    """Render version-controlled HTML email templates."""
+
+    async def render_email_template(self, template_name: str, **context: object) -> str: ...

--- a/portal/domain/org/constants.py
+++ b/portal/domain/org/constants.py
@@ -30,6 +30,13 @@ class MinistryApprovalStatus(str, Enum):
     REJECTED = "rejected"
 
 
+class MinistryDecisionChannel(str, Enum):
+    """Who decided a ministry application and which email copy to use."""
+
+    INCUMBENT = "incumbent"
+    STAFF = "staff"
+
+
 class PositionTeam(str, Enum):
     """Church leadership team grouping."""
 

--- a/portal/providers/template_render_provider.py
+++ b/portal/providers/template_render_provider.py
@@ -1,0 +1,35 @@
+"""
+Jinja2 email template renderer.
+"""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, Template
+
+
+class TemplateRenderProvider:
+    """Render HTML email templates from portal/templates/."""
+
+    def __init__(self, templates_root: Path | None = None):
+        self._templates_root = templates_root or Path(__file__).resolve().parents[1] / "templates"
+
+    def _template_dirs(self, scan_path: Path) -> list[str]:
+        paths = [str(scan_path)]
+        if not scan_path.is_dir():
+            return paths
+        for child in scan_path.iterdir():
+            if child.is_dir():
+                paths.extend(self._template_dirs(child))
+        return paths
+
+    @property
+    def _environment(self) -> Environment:
+        return Environment(loader=FileSystemLoader(searchpath=self._template_dirs(self._templates_root)), enable_async=True, autoescape=True)
+
+    @staticmethod
+    async def _render(template: Template, **context: object) -> str:
+        return await template.render_async(**context)
+
+    async def render_email_template(self, template_name: str, **context: object) -> str:
+        template = self._environment.get_template(name=template_name)
+        return await self._render(template, **context)

--- a/portal/templates/email/base.html
+++ b/portal/templates/email/base.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}New Life{% endblock %}</title>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #e9f3f5; font-family: Arial, Helvetica, sans-serif; color: #1e283f;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #e9f3f5; padding: 24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden;">
+            {% include "email/partials/header.html" %}
+            <tr>
+              <td style="padding: 24px 32px;">
+                {% block content %}{% endblock %}
+              </td>
+            </tr>
+            {% include "email/partials/footer.html" %}
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/portal/templates/email/ministry/applicant_decision_approved.html
+++ b/portal/templates/email/ministry/applicant_decision_approved.html
@@ -1,0 +1,35 @@
+{% extends "email/base.html" %}
+
+{% block title %}Ministry Application Approved{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px; font-size: 16px;">Hello,</p>
+{% if decision_channel == "staff" %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  Your ministry application for <strong>{{ ministry_name_en }}</strong> has been approved by <strong>{{ staff_display_name }}</strong> on behalf of the Owner-position incumbent (<strong>{{ incumbent_display_name }}</strong>).
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  Your ministry application for <strong>{{ ministry_name_en }}</strong> has been approved.
+</p>
+{% endif %}
+<p style="margin: 0 0 16px;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">View My Ministry</a>
+</p>
+
+{% include "email/partials/bilingual_divider.html" %}
+
+<p style="margin: 0 0 16px; font-size: 16px;">您好，</p>
+{% if decision_channel == "staff" %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  您的事工申請「<strong>{{ ministry_name_zh }}</strong>」已由 <strong>{{ staff_display_name }}</strong> 代表 Owner 職位現任者（<strong>{{ incumbent_display_name }}</strong>）核准。
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  您的事工申請「<strong>{{ ministry_name_zh }}</strong>」已獲核准。
+</p>
+{% endif %}
+<p style="margin: 0;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">查看我的事工</a>
+</p>
+{% endblock %}

--- a/portal/templates/email/ministry/applicant_decision_rejected.html
+++ b/portal/templates/email/ministry/applicant_decision_rejected.html
@@ -1,0 +1,37 @@
+{% extends "email/base.html" %}
+
+{% block title %}Ministry Application Declined{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px; font-size: 16px;">Hello,</p>
+{% if decision_channel == "staff" %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  Your ministry application for <strong>{{ ministry_name_en }}</strong> was not approved by <strong>{{ staff_display_name }}</strong> on behalf of the Owner-position incumbent (<strong>{{ incumbent_display_name }}</strong>).
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  Your ministry application for <strong>{{ ministry_name_en }}</strong> was not approved.
+</p>
+{% endif %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">Reason: {{ rejection_reason }}</p>
+<p style="margin: 0 0 16px;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">View My Ministry</a>
+</p>
+
+{% include "email/partials/bilingual_divider.html" %}
+
+<p style="margin: 0 0 16px; font-size: 16px;">您好，</p>
+{% if decision_channel == "staff" %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  您的事工申請「<strong>{{ ministry_name_zh }}</strong>」未獲 <strong>{{ staff_display_name }}</strong> 代表 Owner 職位現任者（<strong>{{ incumbent_display_name }}</strong>）核准。
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  您的事工申請「<strong>{{ ministry_name_zh }}</strong>」未獲核准。
+</p>
+{% endif %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">原因：{{ rejection_reason }}</p>
+<p style="margin: 0;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">查看我的事工</a>
+</p>
+{% endblock %}

--- a/portal/templates/email/ministry/applicant_submit_confirmation.html
+++ b/portal/templates/email/ministry/applicant_submit_confirmation.html
@@ -1,0 +1,23 @@
+{% extends "email/base.html" %}
+
+{% block title %}Ministry Application Submitted{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px; font-size: 16px;">Hello,</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  Your ministry application for <strong>{{ ministry_name_en }}</strong> has been submitted and is pending approval.
+</p>
+<p style="margin: 0 0 16px;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">View My Ministry</a>
+</p>
+
+{% include "email/partials/bilingual_divider.html" %}
+
+<p style="margin: 0 0 16px; font-size: 16px;">您好，</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  您的事工申請「<strong>{{ ministry_name_zh }}</strong>」已成功提交，正在等待核准。
+</p>
+<p style="margin: 0;">
+  <a href="{{ my_ministry_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">查看我的事工</a>
+</p>
+{% endblock %}

--- a/portal/templates/email/ministry/incumbent_notification.html
+++ b/portal/templates/email/ministry/incumbent_notification.html
@@ -1,0 +1,26 @@
+{% extends "email/base.html" %}
+
+{% block title %}Ministry Application Pending Approval{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px; font-size: 16px;">Hello,</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ applicant_display_name }}</strong> submitted a ministry application for <strong>{{ ministry_name_en }}</strong>.
+</p>
+
+{% include "email/partials/application_summary.html" %}
+
+<p style="margin: 0 0 16px;">
+  <a href="{{ approval_detail_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">Review application</a>
+</p>
+
+{% include "email/partials/bilingual_divider.html" %}
+
+<p style="margin: 0 0 16px; font-size: 16px;">您好，</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ applicant_display_name }}</strong> 提交了事工申請「<strong>{{ ministry_name_zh }}</strong>」。
+</p>
+<p style="margin: 0;">
+  <a href="{{ approval_detail_url }}" style="display: inline-block; background-color: #1865d8; color: #ffffff; text-decoration: none; padding: 10px 18px; border-radius: 6px; font-weight: bold;">審核申請</a>
+</p>
+{% endblock %}

--- a/portal/templates/email/ministry/incumbent_staff_decision_notification.html
+++ b/portal/templates/email/ministry/incumbent_staff_decision_notification.html
@@ -1,0 +1,33 @@
+{% extends "email/base.html" %}
+
+{% block title %}Ministry Application Decision{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px; font-size: 16px;">Hello,</p>
+{% if approved %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ staff_display_name }}</strong> approved the ministry application for <strong>{{ ministry_name_en }}</strong> on your behalf as the Owner-position incumbent.
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ staff_display_name }}</strong> declined the ministry application for <strong>{{ ministry_name_en }}</strong> on your behalf as the Owner-position incumbent.
+</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">Reason: {{ rejection_reason }}</p>
+{% endif %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">No further action is required from you.</p>
+
+{% include "email/partials/bilingual_divider.html" %}
+
+<p style="margin: 0 0 16px; font-size: 16px;">您好，</p>
+{% if approved %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ staff_display_name }}</strong> 已代表您（Owner 職位現任者）核准事工申請「<strong>{{ ministry_name_zh }}</strong>」。
+</p>
+{% else %}
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+  <strong>{{ staff_display_name }}</strong> 已代表您（Owner 職位現任者）拒絕事工申請「<strong>{{ ministry_name_zh }}</strong>」。
+</p>
+<p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">原因：{{ rejection_reason }}</p>
+{% endif %}
+<p style="margin: 0; font-size: 16px; line-height: 1.5;">您無需再採取任何行動。</p>
+{% endblock %}

--- a/portal/templates/email/partials/application_summary.html
+++ b/portal/templates/email/partials/application_summary.html
@@ -1,0 +1,58 @@
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 16px 0; background-color: #e9f3f5; border-radius: 6px;">
+  <tr>
+    <td style="padding: 16px;">
+      <p style="margin: 0 0 12px; font-size: 14px; font-weight: bold; color: #1e283f;">Application summary</p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size: 14px; color: #1e283f;">
+        <tr>
+          <td style="padding: 4px 0; width: 40%; color: #5a6478;">Ministry type</td>
+          <td style="padding: 4px 0;">{{ application_summary.ministry_type_name }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">Applicant</td>
+          <td style="padding: 4px 0;">{{ application_summary.applicant_display_name }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">Submitted</td>
+          <td style="padding: 4px 0;">{{ application_summary.submitted_at_display }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">Target audiences</td>
+          <td style="padding: 4px 0;">{{ application_summary.target_audience_names }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">Primary steward</td>
+          <td style="padding: 4px 0;">{{ application_summary.primary_steward_display_name }}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 16px 0; background-color: #e9f3f5; border-radius: 6px;">
+  <tr>
+    <td style="padding: 16px;">
+      <p style="margin: 0 0 12px; font-size: 14px; font-weight: bold; color: #1e283f;">申請摘要</p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size: 14px; color: #1e283f;">
+        <tr>
+          <td style="padding: 4px 0; width: 40%; color: #5a6478;">事工類型</td>
+          <td style="padding: 4px 0;">{{ application_summary.ministry_type_name }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">申請人</td>
+          <td style="padding: 4px 0;">{{ application_summary.applicant_display_name }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">提交時間</td>
+          <td style="padding: 4px 0;">{{ application_summary.submitted_at_display }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">目標對象</td>
+          <td style="padding: 4px 0;">{{ application_summary.target_audience_names }}</td>
+        </tr>
+        <tr>
+          <td style="padding: 4px 0; color: #5a6478;">主要同工</td>
+          <td style="padding: 4px 0;">{{ application_summary.primary_steward_display_name }}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/portal/templates/email/partials/bilingual_divider.html
+++ b/portal/templates/email/partials/bilingual_divider.html
@@ -1,0 +1,1 @@
+<hr style="border: none; border-top: 1px solid #e9f3f5; margin: 24px 0;" />

--- a/portal/templates/email/partials/footer.html
+++ b/portal/templates/email/partials/footer.html
@@ -1,0 +1,5 @@
+<tr>
+  <td style="padding: 16px 32px 24px; font-size: 12px; color: #5a6478; text-align: center; border-top: 1px solid #e9f3f5;">
+    New Life Church &middot; Facility Booking
+  </td>
+</tr>

--- a/portal/templates/email/partials/header.html
+++ b/portal/templates/email/partials/header.html
@@ -1,0 +1,5 @@
+<tr>
+  <td style="background-color: #1e283f; padding: 20px 32px; text-align: center; border-bottom: 4px solid #fab148;">
+    <span style="color: #ffffff; font-size: 20px; font-weight: bold; letter-spacing: 0.5px;">New Life Facility Booking</span>
+  </td>
+</tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "cryptography>=47,<48",
     "email-validator",
     "httpx",
+    "jinja2",
     "pillow",
     "python-multipart",
     "ujson",

--- a/tests/application/org/test_ministry_application_mail_content.py
+++ b/tests/application/org/test_ministry_application_mail_content.py
@@ -1,19 +1,19 @@
 """
-Tests for ministry application bilingual mail content.
+Tests for ministry application bilingual mail content helpers.
 """
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from portal.application.org.ministry_application_mail_content import (
     EN_LOCALE_ID,
     ZH_TW_LOCALE_ID,
-    build_applicant_approved_html,
-    build_applicant_rejected_html,
-    build_applicant_submit_confirmation_html,
-    build_incumbent_notification_html,
+    build_application_summary_context,
+    format_submitted_at_toronto,
     resolve_bilingual_ministry_names,
 )
-from portal.application.org.results import TranslationItemResult
+from portal.application.org.results import MinistryDetailResult, MinistryMemberResult, MinistryTypeResult, TargetAudienceResult, TranslationItemResult
+from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 
 
 def test_resolve_bilingual_ministry_names_uses_locale_translations():
@@ -25,38 +25,32 @@ def test_resolve_bilingual_ministry_names_uses_locale_translations():
     assert chinese_name == zh_name
 
 
-def test_applicant_submit_confirmation_html_is_bilingual_en_then_zh():
-    html = build_applicant_submit_confirmation_html(
-        ministry_name_en="Badminton", ministry_name_zh="羽毛球", my_ministry_url="http://localhost:5174/my-ministry"
+def test_format_submitted_at_toronto_converts_utc_to_toronto():
+    submitted_at = datetime(2026, 1, 15, 18, 30, tzinfo=timezone.utc)
+    display = format_submitted_at_toronto(submitted_at)
+    assert "2026-01-15" in display
+    assert "EST" in display or "EDT" in display
+
+
+def test_build_application_summary_context_includes_key_fields():
+    applicant_user_id = uuid4()
+    ministry = MinistryDetailResult(
+        id=uuid4(),
+        name="Badminton",
+        status=MinistryStatus.PENDING_APPROVAL.value,
+        ministry_type_name="Sports",
+        submitted_at=datetime(2026, 1, 15, 18, 30, tzinfo=timezone.utc),
+        has_priority_booking=False,
+        is_active=True,
+        target_audiences=[TargetAudienceResult(id=uuid4(), code="youth", name="Youth")],
+        members=[
+            MinistryMemberResult(user_id=applicant_user_id, member_role=MinistryMemberRole.PRIMARY.value, display_name="Primary Steward"),
+            MinistryMemberResult(user_id=uuid4(), member_role=MinistryMemberRole.SECONDARY.value, display_name="Secondary"),
+        ],
     )
-    assert "Badminton" in html
-    assert "羽毛球" in html
-    assert html.index("Hello,") < html.index("您好")
-    assert "http://localhost:5174/my-ministry" in html
-
-
-def test_incumbent_notification_html_includes_approval_deep_link():
-    ministry_id = uuid4()
-    approval_url = f"http://localhost:5174/my-ministry/approvals/{ministry_id}"
-    html = build_incumbent_notification_html(
-        ministry_name_en="Badminton", ministry_name_zh="羽毛球", applicant_display_name="Jane Applicant", approval_detail_url=approval_url
-    )
-    assert approval_url in html
-    assert "Jane Applicant" in html
-    assert html.index("Review application") < html.index("審核申請")
-
-
-def test_applicant_approved_html_is_bilingual_en_then_zh():
-    html = build_applicant_approved_html(ministry_name_en="Badminton", ministry_name_zh="羽毛球", my_ministry_url="http://localhost:5174/my-ministry")
-    assert "has been approved" in html
-    assert "已獲核准" in html
-    assert html.index("Hello,") < html.index("您好")
-
-
-def test_applicant_rejected_html_includes_reason_bilingual():
-    html = build_applicant_rejected_html(
-        ministry_name_en="Badminton", ministry_name_zh="羽毛球", rejection_reason="Incomplete roster", my_ministry_url="http://localhost:5174/my-ministry"
-    )
-    assert "Incomplete roster" in html
-    assert "未獲核准" in html
-    assert html.index("Reason:") < html.index("原因：")
+    summary = build_application_summary_context(ministry=ministry, applicant_display_name="Jane Applicant")
+    assert summary.ministry_type_name == "Sports"
+    assert summary.applicant_display_name == "Jane Applicant"
+    assert summary.target_audience_names == "Youth"
+    assert summary.primary_steward_display_name == "Primary Steward"
+    assert "2026-01-15" in summary.submitted_at_display

--- a/tests/application/org/test_ministry_application_mail_service.py
+++ b/tests/application/org/test_ministry_application_mail_service.py
@@ -2,6 +2,7 @@
 Tests for ministry application mail dispatch.
 """
 
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -9,8 +10,9 @@ import pytest
 from portal.application.auth.results import UserDetail, UserSensitive
 from portal.application.org.ministry_application_mail_content import EN_LOCALE_ID, ZH_TW_LOCALE_ID
 from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
-from portal.application.org.results import MinistryDetailResult, TranslationItemResult
-from portal.domain.org.constants import MinistryStatus
+from portal.application.org.results import MinistryDetailResult, MinistryMemberResult, TargetAudienceResult, TranslationItemResult
+from portal.domain.org.constants import MinistryDecisionChannel, MinistryMemberRole, MinistryStatus
+from portal.providers.template_render_provider import TemplateRenderProvider
 from tests.fixtures.org.stubs import StubMinistryRepository, StubPositionRepository
 
 
@@ -34,6 +36,27 @@ class StubMailUserRepository:
         return self.profiles.get(user_id)
 
 
+def make_mail_service(
+    mail_port: StubMailSendPort,
+    ministry_stub: StubMinistryRepository,
+    position_stub: StubPositionRepository,
+    user_stub: StubMailUserRepository,
+    *,
+    enabled: bool = True,
+    override_recipients: list[str] | None = None,
+) -> MinistryApplicationMailService:
+    return MinistryApplicationMailService(
+        mail_port,
+        TemplateRenderProvider(),
+        ministry_stub,
+        position_stub,
+        user_stub,
+        facility_booking_base_url="http://localhost:5174",
+        enabled=enabled,
+        override_recipients=override_recipients,
+    )
+
+
 @pytest.mark.asyncio
 async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
     ministry_id = uuid4()
@@ -48,12 +71,16 @@ async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
                 name="Fallback",
                 status=MinistryStatus.PENDING_APPROVAL.value,
                 owner_position_id=owner_position_id,
+                ministry_type_name="Sports",
+                submitted_at=datetime(2026, 1, 15, 18, 30, tzinfo=timezone.utc),
                 has_priority_booking=False,
                 is_active=True,
                 translations=[
                     TranslationItemResult(locale_id=EN_LOCALE_ID, name="Badminton Club"),
                     TranslationItemResult(locale_id=ZH_TW_LOCALE_ID, name="羽毛球社"),
                 ],
+                target_audiences=[TargetAudienceResult(id=uuid4(), code="adults", name="Adults")],
+                members=[MinistryMemberResult(user_id=applicant_user_id, member_role=MinistryMemberRole.PRIMARY.value, display_name="Primary Steward")],
             )
         }
     )
@@ -64,14 +91,7 @@ async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
         },
         profiles={applicant_user_id: UserDetail(id=applicant_user_id, email="applicant@example.com", preferred_name="Applicant Name")},
     )
-    service = MinistryApplicationMailService(
-        mail_port,
-        ministry_stub,
-        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
-        user_stub,
-        facility_booking_base_url="http://localhost:5174",
-        enabled=True,
-    )
+    service = make_mail_service(mail_port, ministry_stub, StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), user_stub)
 
     await service.send_submit_notifications(ministry_id=ministry_id, owner_position_id=owner_position_id, applicant_user_id=applicant_user_id)
 
@@ -81,8 +101,11 @@ async def test_send_submit_notifications_sends_applicant_and_incumbent_emails():
     assert "Badminton Club" in applicant_call["body_html"]
     assert "羽毛球社" in applicant_call["body_html"]
     assert "/my-ministry" in applicant_call["body_html"]
+    assert "New Life Facility Booking" in applicant_call["body_html"]
     assert f"/my-ministry/approvals/{ministry_id}" in incumbent_call["body_html"]
     assert "Applicant Name" in incumbent_call["body_html"]
+    assert "Application summary" in incumbent_call["body_html"]
+    assert "Sports" in incumbent_call["body_html"]
 
 
 @pytest.mark.asyncio
@@ -110,14 +133,8 @@ async def test_send_submit_notifications_redirects_to_override_recipients():
             incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
         }
     )
-    service = MinistryApplicationMailService(
-        mail_port,
-        ministry_stub,
-        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
-        user_stub,
-        facility_booking_base_url="http://localhost:5174",
-        enabled=True,
-        override_recipients=["dev@local.test"],
+    service = make_mail_service(
+        mail_port, ministry_stub, StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), user_stub, override_recipients=["dev@local.test"]
     )
 
     await service.send_submit_notifications(ministry_id=ministry_id, owner_position_id=owner_position_id, applicant_user_id=applicant_user_id)
@@ -132,13 +149,59 @@ async def test_send_submit_notifications_redirects_to_override_recipients():
 @pytest.mark.asyncio
 async def test_send_submit_notifications_noop_when_disabled():
     mail_port = StubMailSendPort()
-    service = MinistryApplicationMailService(
-        mail_port,
-        StubMinistryRepository(),
-        StubPositionRepository(),
-        StubMailUserRepository(users={}),
-        facility_booking_base_url="http://localhost:5174",
-        enabled=False,
-    )
+    service = make_mail_service(mail_port, StubMinistryRepository(), StubPositionRepository(), StubMailUserRepository(users={}), enabled=False)
     await service.send_submit_notifications(ministry_id=uuid4(), owner_position_id=uuid4(), applicant_user_id=uuid4())
     assert mail_port.calls == []
+
+
+@pytest.mark.asyncio
+async def test_send_decision_notification_staff_channel_sends_applicant_and_incumbent_emails():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    staff_user_id = uuid4()
+    mail_port = StubMailSendPort()
+    ministry_stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(
+                id=ministry_id,
+                name="Badminton",
+                status=MinistryStatus.PENDING_APPROVAL.value,
+                owner_position_id=owner_position_id,
+                submitted_by_id=applicant_user_id,
+                has_priority_booking=False,
+                is_active=True,
+                translations=[TranslationItemResult(locale_id=EN_LOCALE_ID, name="Badminton Club")],
+            )
+        }
+    )
+    user_stub = StubMailUserRepository(
+        users={
+            applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+            incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+            staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
+        },
+        profiles={
+            staff_user_id: UserDetail(id=staff_user_id, email="staff@example.com", preferred_name="Staff Member"),
+            incumbent_user_id: UserDetail(id=incumbent_user_id, email="incumbent@example.com", preferred_name="Incumbent Leader"),
+        },
+    )
+    service = make_mail_service(mail_port, ministry_stub, StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), user_stub)
+
+    await service.send_decision_notification(
+        ministry_id=ministry_id,
+        applicant_user_id=applicant_user_id,
+        approved=True,
+        decision_channel=MinistryDecisionChannel.STAFF,
+        decided_by_user_id=staff_user_id,
+        owner_position_id=owner_position_id,
+    )
+
+    assert len(mail_port.calls) == 2
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    incumbent_call = next(call for call in mail_port.calls if call["to_email"] == "incumbent@example.com")
+    assert "Staff Member" in applicant_call["body_html"]
+    assert "Incumbent Leader" in applicant_call["body_html"]
+    assert "on your behalf" in incumbent_call["body_html"]
+    assert "Staff Member" in incumbent_call["body_html"]

--- a/tests/application/org/test_ministry_services.py
+++ b/tests/application/org/test_ministry_services.py
@@ -42,10 +42,11 @@ from portal.application.org.steward_directory_query import matches_steward_direc
 from portal.application.org.target_audience_validation import validate_target_audience_ids
 from portal.domain.facility.days_of_week_mask import days_to_mask, mask_to_days
 from portal.domain.org.catalog_codes import TARGET_AUDIENCE_ADULTS, TARGET_AUDIENCE_ALL_AGES
-from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
+from portal.domain.org.constants import MinistryDecisionChannel, MinistryMemberRole, MinistryStatus
 from portal.exceptions.responses import BadRequestException, ForbiddenException, NotFoundException
 from portal.libs.contexts.user_context import UserContext
-from tests.application.org.test_ministry_application_mail_service import StubMailSendPort, StubMailUserRepository
+from portal.providers.template_render_provider import TemplateRenderProvider
+from tests.application.org.test_ministry_application_mail_service import StubMailSendPort, StubMailUserRepository, make_mail_service
 from tests.fixtures.org.stubs import (
     StubMinistryRepository,
     StubMinistryTypeRepository,
@@ -504,7 +505,7 @@ async def test_submit_ministry_dispatches_submit_mail_notifications():
         },
     )
     mail_port = StubMailSendPort()
-    mail_service = MinistryApplicationMailService(
+    mail_service = make_mail_service(
         mail_port,
         stub,
         StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
@@ -514,8 +515,6 @@ async def test_submit_ministry_dispatches_submit_mail_notifications():
                 incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
             }
         ),
-        facility_booking_base_url="http://localhost:5174",
-        enabled=True,
     )
     approval_service = make_approval_service(
         stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
@@ -749,15 +748,13 @@ async def test_approve_ministry_as_incumbent_dispatches_decision_mail():
     ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
     stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
     mail_port = StubMailSendPort()
-    mail_service = MinistryApplicationMailService(
+    mail_service = make_mail_service(
         mail_port,
         stub,
         StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
         StubMailUserRepository(
             users={applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False)}
         ),
-        facility_booking_base_url="http://localhost:5174",
-        enabled=True,
     )
     approval_service = make_approval_service(
         stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
@@ -794,15 +791,13 @@ async def test_reject_ministry_as_incumbent_dispatches_decision_mail():
     ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
     stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
     mail_port = StubMailSendPort()
-    mail_service = MinistryApplicationMailService(
+    mail_service = make_mail_service(
         mail_port,
         stub,
         StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
         StubMailUserRepository(
             users={applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False)}
         ),
-        facility_booking_base_url="http://localhost:5174",
-        enabled=True,
     )
     approval_service = make_approval_service(
         stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
@@ -818,17 +813,74 @@ async def test_reject_ministry_as_incumbent_dispatches_decision_mail():
 
 
 @pytest.mark.asyncio
-async def test_admin_approve_ministry_does_not_dispatch_decision_mail():
+async def test_admin_approve_ministry_dispatches_staff_decision_mails():
     ministry_id = uuid4()
     owner_position_id = uuid4()
-    ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=uuid4())
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    staff_user_id = uuid4()
+    ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
     stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
     mail_port = StubMailSendPort()
-    mail_service = MinistryApplicationMailService(
-        mail_port, stub, StubPositionRepository(), StubMailUserRepository(users={}), facility_booking_base_url="http://localhost:5174", enabled=True
+    mail_service = make_mail_service(
+        mail_port,
+        stub,
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
+        StubMailUserRepository(
+            users={
+                applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+                incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+                staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
+            }
+        ),
     )
-    approval_service = make_approval_service(stub, mail_service=mail_service)
+    approval_service = make_approval_service(
+        stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
+    )
+    approval_service._user_ctx = UserContext(user_id=staff_user_id, email="staff@example.com", is_admin=True, is_superuser=False)
 
-    await approval_service.approve_ministry(ministry_id, ApproveMinistryCommand())
+    await approval_service.approve_ministry(ministry_id, ApproveMinistryCommand(decision_channel=MinistryDecisionChannel.STAFF))
 
-    assert mail_port.calls == []
+    assert len(mail_port.calls) == 2
+    assert {call["to_email"] for call in mail_port.calls} == {"applicant@example.com", "incumbent@example.com"}
+    assert all("Approved" in call["subject"] or "Decision on Your Behalf" in call["subject"] for call in mail_port.calls)
+
+
+@pytest.mark.asyncio
+async def test_admin_reject_ministry_dispatches_staff_decision_mails():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    staff_user_id = uuid4()
+    ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
+    stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
+    mail_port = StubMailSendPort()
+    mail_service = make_mail_service(
+        mail_port,
+        stub,
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
+        StubMailUserRepository(
+            users={
+                applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+                incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+                staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
+            }
+        ),
+    )
+    approval_service = make_approval_service(
+        stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
+    )
+    approval_service._user_ctx = UserContext(user_id=staff_user_id, email="staff@example.com", is_admin=True, is_superuser=False)
+
+    await approval_service.reject_ministry(
+        ministry_id, RejectMinistryCommand(rejection_reason="Incomplete roster", decision_channel=MinistryDecisionChannel.STAFF)
+    )
+
+    assert len(mail_port.calls) == 2
+    assert {call["to_email"] for call in mail_port.calls} == {"applicant@example.com", "incumbent@example.com"}
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    assert "Declined" in applicant_call["subject"]
+    assert "Incomplete roster" in applicant_call["body_html"]
+    assert "staff@example.com" not in applicant_call["body_html"]
+    assert "Church staff" in applicant_call["body_html"]

--- a/uv.lock
+++ b/uv.lock
@@ -697,6 +697,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -949,6 +961,7 @@ dependencies = [
     { name = "fastapi-limiter" },
     { name = "gunicorn" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "msal" },
     { name = "msgraph-beta-sdk" },
     { name = "pillow" },
@@ -989,6 +1002,7 @@ requires-dist = [
     { name = "fastapi-limiter" },
     { name = "gunicorn", specifier = ">=25,<26" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "msal" },
     { name = "msgraph-beta-sdk" },
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- Replace inline f-string ministry application email HTML with version-controlled Jinja2 templates under `portal/templates/email/` and a reusable `EmailTemplateRenderPort` (`TemplateRenderProvider`).
- Add Facility Booking branded bilingual email layout (inline CSS) and an application summary block on incumbent pending notifications only.
- Send applicant and incumbent notifications when admin staff approve or reject via `decision_channel=staff`; incumbent member decisions continue to use `decision_channel=incumbent` with applicant-only mail.

Closes #110

## Test plan

- [x] `uv run ruff format && uv run ruff check --fix`
- [x] `uv run pytest tests/application/org/test_ministry_application_mail_content.py tests/application/org/test_ministry_application_mail_service.py tests/application/org/test_ministry_services.py -v`
- [x] `uv run pytest` (370 passed; 1 pre-existing failure in `test_create_rate_unique_conflict` unrelated to this branch)


Made with [Cursor](https://cursor.com)