### PR TITLE
feat: enable staff decision mail on admin ministry approve/reject (#112)

### DIFF
--- a/portal/application/org/mappers.py
+++ b/portal/application/org/mappers.py
@@ -50,6 +50,7 @@ from portal.application.org.results import (
     TranslationItemResult,
 )
 from portal.domain.common.mixins import UUIDBaseModel
+from portal.domain.org.constants import MinistryDecisionChannel
 from portal.serializers.admin.v1.ministry import (
     AdminMinistryApplicationCreate,
     AdminMinistryApprove,
@@ -254,11 +255,11 @@ def replace_ministry_members_to_command(model: AdminMinistryReplaceMembers) -> R
 
 
 def approve_ministry_to_command(model: AdminMinistryApprove) -> ApproveMinistryCommand:
-    return ApproveMinistryCommand(comment=model.comment)
+    return ApproveMinistryCommand(comment=model.comment, decision_channel=MinistryDecisionChannel.STAFF)
 
 
 def reject_ministry_to_command(model: AdminMinistryReject) -> RejectMinistryCommand:
-    return RejectMinistryCommand(rejection_reason=model.rejection_reason, comment=model.comment)
+    return RejectMinistryCommand(rejection_reason=model.rejection_reason, comment=model.comment, decision_channel=MinistryDecisionChannel.STAFF)
 
 
 def ministry_detail_to_api(result: MinistryDetailResult) -> AdminMinistryDetail:

--- a/tests/application/org/test_ministry_application_mail_service.py
+++ b/tests/application/org/test_ministry_application_mail_service.py
@@ -257,3 +257,59 @@ async def test_send_decision_notification_staff_channel_sends_applicant_and_incu
     assert "Incumbent Leader" in applicant_call["body_html"]
     assert "on your behalf" in incumbent_call["body_html"]
     assert "Staff Member" in incumbent_call["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_send_decision_notification_staff_channel_reject_includes_reason_and_incumbent_notification():
+    ministry_id = uuid4()
+    owner_position_id = uuid4()
+    applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
+    staff_user_id = uuid4()
+    mail_port = StubMailSendPort()
+    ministry_stub = StubMinistryRepository(
+        ministry_by_id={
+            ministry_id: MinistryDetailResult(
+                id=ministry_id,
+                name="Badminton",
+                status=MinistryStatus.PENDING_APPROVAL.value,
+                owner_position_id=owner_position_id,
+                submitted_by_id=applicant_user_id,
+                has_priority_booking=False,
+                is_active=True,
+                translations=[TranslationItemResult(locale_id=EN_LOCALE_ID, name="Badminton Club")],
+            )
+        }
+    )
+    user_stub = StubMailUserRepository(
+        users={
+            applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+            incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
+            staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
+        },
+        profiles={
+            staff_user_id: UserDetail(id=staff_user_id, email="staff@example.com", preferred_name="Staff Member"),
+            incumbent_user_id: UserDetail(id=incumbent_user_id, email="incumbent@example.com", preferred_name="Incumbent Leader"),
+        },
+    )
+    service = make_mail_service(mail_port, ministry_stub, StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), user_stub)
+
+    await service.send_decision_notification(
+        ministry_id=ministry_id,
+        applicant_user_id=applicant_user_id,
+        approved=False,
+        decision_channel=MinistryDecisionChannel.STAFF,
+        decided_by_user_id=staff_user_id,
+        owner_position_id=owner_position_id,
+        rejection_reason="Incomplete roster",
+    )
+
+    assert len(mail_port.calls) == 2
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    incumbent_call = next(call for call in mail_port.calls if call["to_email"] == "incumbent@example.com")
+    assert "Incomplete roster" in applicant_call["body_html"]
+    assert "Staff Member" in applicant_call["body_html"]
+    assert "Incumbent Leader" in applicant_call["body_html"]
+    assert "staff@example.com" not in applicant_call["body_html"]
+    assert "Incomplete roster" in incumbent_call["body_html"]
+    assert "No further action" in incumbent_call["body_html"]

--- a/tests/application/org/test_ministry_services.py
+++ b/tests/application/org/test_ministry_services.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import ValidationError
 
-from portal.application.auth.results import UserSensitive
+from portal.application.auth.results import UserDetail, UserSensitive
 from portal.application.org.commands import (
     ApproveMinistryCommand,
     CreateMinistryCommand,
@@ -24,6 +24,7 @@ from portal.application.org.commands import (
     SubmitMinistryCommand,
     UpdateRejectedMinistryApplicationCommand,
 )
+from portal.application.org.mappers import approve_ministry_to_command, reject_ministry_to_command
 from portal.application.org.ministry_application_mail_content import EN_LOCALE_ID
 from portal.application.org.ministry_application_mail_service import MinistryApplicationMailService
 from portal.application.org.ministry_approval_service import MinistryApprovalService
@@ -46,6 +47,7 @@ from portal.domain.org.constants import MinistryMemberRole, MinistryStatus
 from portal.exceptions.responses import BadRequestException, ForbiddenException, NotFoundException
 from portal.libs.contexts.user_context import UserContext
 from portal.providers.template_render_provider import TemplateRenderProvider
+from portal.serializers.admin.v1.ministry import AdminMinistryApprove, AdminMinistryReject
 from tests.application.org.test_ministry_application_mail_service import StubMailSendPort, StubMailUserRepository, make_mail_service
 from tests.fixtures.org.stubs import (
     StubMinistryRepository,
@@ -819,10 +821,11 @@ async def test_reject_ministry_as_incumbent_dispatches_decision_mail():
 
 
 @pytest.mark.asyncio
-async def test_admin_approve_ministry_does_not_dispatch_decision_mail():
+async def test_admin_approve_ministry_dispatches_staff_decision_mails():
     ministry_id = uuid4()
     owner_position_id = uuid4()
     applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
     staff_user_id = uuid4()
     ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
     stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
@@ -830,28 +833,47 @@ async def test_admin_approve_ministry_does_not_dispatch_decision_mail():
     mail_service = make_mail_service(
         mail_port,
         stub,
-        StubPositionRepository(incumbents={owner_position_id: uuid4()}),
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
         StubMailUserRepository(
             users={
                 applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+                incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
                 staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
-            }
+            },
+            profiles={
+                staff_user_id: UserDetail(id=staff_user_id, email="staff@example.com", preferred_name="Staff Member"),
+                incumbent_user_id: UserDetail(id=incumbent_user_id, email="incumbent@example.com", preferred_name="Incumbent Leader"),
+            },
         ),
     )
-    approval_service = make_approval_service(stub, mail_service=mail_service)
+    approval_service = make_approval_service(
+        stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
+    )
     approval_service._user_ctx = UserContext(user_id=staff_user_id, email="staff@example.com", is_admin=True, is_superuser=False)
 
-    await approval_service.approve_ministry(ministry_id, ApproveMinistryCommand())
+    await approval_service.approve_ministry(ministry_id, approve_ministry_to_command(AdminMinistryApprove()))
 
-    assert mail_port.calls == []
+    assert len(mail_port.calls) == 2
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    incumbent_call = next(call for call in mail_port.calls if call["to_email"] == "incumbent@example.com")
+    assert "Approved" in applicant_call["subject"]
+    assert "Decision on Your Behalf" in incumbent_call["subject"]
+    assert "Staff Member" in applicant_call["body_html"]
+    assert "Incumbent Leader" in applicant_call["body_html"]
+    assert "on behalf of" in applicant_call["body_html"]
+    assert "staff@example.com" not in applicant_call["body_html"]
+    assert "on your behalf" in incumbent_call["body_html"]
+    assert "No further action" in incumbent_call["body_html"]
     assert stub.update_calls[-1]["values"]["status"] == MinistryStatus.ACTIVE.value
+    assert stub.update_calls[-1]["values"]["approved_by_id"] == staff_user_id
 
 
 @pytest.mark.asyncio
-async def test_admin_reject_ministry_does_not_dispatch_decision_mail():
+async def test_admin_reject_ministry_dispatches_staff_decision_mails():
     ministry_id = uuid4()
     owner_position_id = uuid4()
     applicant_user_id = uuid4()
+    incumbent_user_id = uuid4()
     staff_user_id = uuid4()
     ministry = _pending_ministry(ministry_id=ministry_id, owner_position_id=owner_position_id, submitted_by_id=applicant_user_id)
     stub = StubMinistryRepository(ministry_by_id={ministry_id: ministry})
@@ -859,21 +881,34 @@ async def test_admin_reject_ministry_does_not_dispatch_decision_mail():
     mail_service = make_mail_service(
         mail_port,
         stub,
-        StubPositionRepository(incumbents={owner_position_id: uuid4()}),
+        StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}),
         StubMailUserRepository(
             users={
                 applicant_user_id: UserSensitive(id=applicant_user_id, email="applicant@example.com", verified=True, is_active=True, is_admin=False),
+                incumbent_user_id: UserSensitive(id=incumbent_user_id, email="incumbent@example.com", verified=True, is_active=True, is_admin=False),
                 staff_user_id: UserSensitive(id=staff_user_id, email="staff@example.com", verified=True, is_active=True, is_admin=True),
-            }
+            },
+            profiles={staff_user_id: UserDetail(id=staff_user_id, email="staff@example.com", preferred_name="Staff Member")},
         ),
     )
-    approval_service = make_approval_service(stub, mail_service=mail_service)
+    approval_service = make_approval_service(
+        stub, position_stub=StubPositionRepository(incumbents={owner_position_id: incumbent_user_id}), mail_service=mail_service
+    )
     approval_service._user_ctx = UserContext(user_id=staff_user_id, email="staff@example.com", is_admin=True, is_superuser=False)
 
-    await approval_service.reject_ministry(ministry_id, RejectMinistryCommand(rejection_reason="Incomplete roster"))
+    await approval_service.reject_ministry(ministry_id, reject_ministry_to_command(AdminMinistryReject(rejection_reason="Incomplete roster")))
 
-    assert mail_port.calls == []
+    assert len(mail_port.calls) == 2
+    applicant_call = next(call for call in mail_port.calls if call["to_email"] == "applicant@example.com")
+    incumbent_call = next(call for call in mail_port.calls if call["to_email"] == "incumbent@example.com")
+    assert "Declined" in applicant_call["subject"]
+    assert "Incomplete roster" in applicant_call["body_html"]
+    assert "Staff Member" in applicant_call["body_html"]
+    assert "staff@example.com" not in applicant_call["body_html"]
+    assert "Staff Member" in incumbent_call["body_html"]
+    assert "No further action" in incumbent_call["body_html"]
     assert stub.update_calls[-1]["values"]["status"] == MinistryStatus.REJECTED.value
+    assert stub.update_calls[-1]["values"]["rejected_by_id"] == staff_user_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enable admin portal ministry approve/reject to dispatch staff-channel decision emails. Admin mappers now pass `decision_channel=staff`, triggering the applicant decision mail and incumbent staff-decision notification built in #110/#111.

Closes #112

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

#111 intentionally deferred wiring `decision_channel=staff` on admin routes until this ticket. Mail templates and `MinistryApplicationMailService` staff-channel dual dispatch were already in place; this PR only reconnects the admin mapper and updates tests.

## Testing

- [x] `uv run pytest tests/application/org/test_ministry_application_mail_service.py tests/application/org/test_ministry_services.py -v`
- [x] `uv run ruff format` and `uv run ruff check --fix` on changed files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)