### PR TITLE
feat: add member mock-login API for Facility Booking QA (#119)

### DIFF
--- a/docs/adr/0014-mock-login-member-auth.md
+++ b/docs/adr/0014-mock-login-member-auth.md
@@ -1,0 +1,19 @@
+# Member mock login for Facility Booking QA (dev/staging only)
+
+Facility Booking QA needs passwordless member sign-in without Microsoft Entra ID, with **real** JWTs and per-account ministry/booking authorization — not a frontend fake session. We add `POST /api/v1/auth/mock-login` (`{ email }`, snake_case) on the member app surface. It is enabled only when `MOCK_LOGIN_ENABLED=true` (non-production deployments). The email must end with the configured testing suffix (default `@test.local` via `TESTING_ACCOUNT_EMAIL_SUFFIX`). The user must already exist in `auth.user`, be `verified` and `is_active`. Request Origin must resolve to a registered member web app (`MEMBER_WEB_APPS`). Staging also requires header `X-Mock-Login-Secret` matching `MOCK_LOGIN_SECRET`. On success we reuse `LoginService.complete_member_login` (same token shape as `/auth/login/microsoft`). Failed suffix, missing user, disabled feature, bad Origin, or bad secret all return generic `401` (no account enumeration). Testing accounts are provisioned by operator CLI only ([#118](https://github.com/efcnewlife/newlife-core-api/issues/118)); no `is_testing_account` column. Product context and frontend consequences: [`efcnewlife/facility-booking-frontend` ADR 0021](https://github.com/efcnewlife/facility-booking-frontend/blob/main/docs/adr/0021-mock-login.md).
+
+## Considered Options
+
+- **`is_testing_account` on `auth.user`** — rejected: `@test.local` suffix is sufficient; avoids migration and Admin UI; trade-off is testing emails cannot use production-looking domains.
+- **Separate login service path with elevated scopes** — rejected: mock login must exercise the same member authorization as Microsoft login.
+- **Production mock login with IP allowlist** — rejected: dev and staging only.
+- **`POST /api/v1/auth/login/testing`** — rejected: `/mock-login` matches product language (facility-booking ADR 0021).
+
+## Consequences
+
+- New settings: `MOCK_LOGIN_ENABLED`, `MOCK_LOGIN_SECRET`, `TESTING_ACCOUNT_EMAIL_SUFFIX`; document in `example.env`.
+- New application service (or method on existing auth service), delivery route under `portal/routers/apis/v1/auth.py`, request serializer, mapper to a small command.
+- No Alembic migration in the mock-login slice (suffix-only identification).
+- CLI `create-mock-user` tracked separately in #118; must enforce `@test.local` (or configured suffix).
+- Audit: log mock-login attempts (success and failure) at application level when implementing.
+- Persona/ministry relationship seeding for `@test.local` users is out of scope — follow-up ticket.

--- a/example.env
+++ b/example.env
@@ -57,5 +57,10 @@ REFRESH_TOKEN_HASH_PEPPER=
 # Member SPAs for /api/v1 auth (Origin -> app_code). Format: code|origin|origin,code|origin
 # MEMBER_WEB_APPS=facility-booking|http://localhost:5174
 
+# Member mock login — dev/staging QA only (POST /api/v1/auth/mock-login). Never enable in production.
+# MOCK_LOGIN_ENABLED=false
+# MOCK_LOGIN_SECRET=change-me-in-staging
+# TESTING_ACCOUNT_EMAIL_SUFFIX=@test.local
+
 # Logging
 SENSITIVE_PARAMS=token,secret,password,old_password,new_password,new_password_confirm

--- a/portal/application/auth/commands.py
+++ b/portal/application/auth/commands.py
@@ -32,6 +32,12 @@ class MicrosoftLoginCommand(BaseModel):
     id_token: str = Field(..., description="Microsoft ID token")
 
 
+class MockLoginCommand(BaseModel):
+    """Member mock login command (dev/staging testing accounts)."""
+
+    email: str = Field(..., description="Testing account email")
+
+
 class LogoutCommand(BaseModel):
     """Logout command."""
 

--- a/portal/application/auth/mock_login_auth_service.py
+++ b/portal/application/auth/mock_login_auth_service.py
@@ -1,0 +1,86 @@
+"""
+Member mock login for dev/staging QA (passwordless testing accounts).
+"""
+
+from typing import Optional
+
+from portal.application.auth.commands import MockLoginCommand
+from portal.application.auth.login_service import LoginService
+from portal.application.auth.member_web_app_resolver import resolve_request_app_code
+from portal.application.auth.results import MemberLoginResult, UserSensitive
+from portal.config import settings
+from portal.domain.auth.member_web_app import MemberWebAppRegistry
+from portal.domain.auth.ports import UserRepositoryPort
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.contexts.request_context import get_request_context
+from portal.libs.logger import logger
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+MOCK_LOGIN_UNAUTHORIZED_DETAIL = "Unauthorized"
+
+
+class MockLoginAuthService:
+    """Passwordless mock login for registered testing-account emails."""
+
+    def __init__(self, user_repository: UserRepositoryPort, login_service: LoginService, member_web_app_registry: Optional[MemberWebAppRegistry] = None):
+        self._repository = user_repository
+        self._login_service = login_service
+        self._member_web_app_registry = member_web_app_registry
+
+    def _is_enabled(self) -> bool:
+        return settings.MOCK_LOGIN_ENABLED and not settings.is_prod
+
+    def _audit(self, *, outcome: str, email: str, reason: str, app_code: Optional[str] = None) -> None:
+        logger.info("mock_login attempt outcome=%s email=%s app_code=%s reason=%s", outcome, email, app_code or "-", reason)
+
+    def _fail(self, *, email: str, reason: str, app_code: Optional[str] = None) -> None:
+        self._audit(outcome="failure", email=email, reason=reason, app_code=app_code)
+        raise UnauthorizedException(detail=MOCK_LOGIN_UNAUTHORIZED_DETAIL)
+
+    def _email_has_testing_suffix(self, email: str) -> bool:
+        suffix = settings.TESTING_ACCOUNT_EMAIL_SUFFIX.strip().lower()
+        if not suffix:
+            return False
+        return email.endswith(suffix)
+
+    def _secret_is_valid(self) -> bool:
+        configured_secret = (settings.MOCK_LOGIN_SECRET or "").strip()
+        req_ctx = get_request_context()
+        header_secret = None
+        if req_ctx and req_ctx.headers:
+            header_secret = req_ctx.headers.mock_login_secret
+        provided = (header_secret or "").strip()
+        if settings.ENV.lower() == "stg":
+            return bool(configured_secret) and provided == configured_secret
+        if not configured_secret:
+            return True
+        return provided == configured_secret
+
+    @distributed_trace()
+    async def mock_member_login(self, command: MockLoginCommand) -> MemberLoginResult:
+        email = command.email.strip().lower()
+        app_code: Optional[str] = None
+
+        if not self._is_enabled():
+            self._fail(email=email, reason="disabled")
+
+        if not self._secret_is_valid():
+            self._fail(email=email, reason="invalid_secret")
+
+        if not self._email_has_testing_suffix(email):
+            self._fail(email=email, reason="invalid_suffix")
+
+        if not self._member_web_app_registry:
+            self._fail(email=email, reason="registry_unconfigured")
+
+        app_code = resolve_request_app_code(self._member_web_app_registry, required=False)
+        if not app_code:
+            self._fail(email=email, reason="unknown_origin")
+
+        user: Optional[UserSensitive] = await self._repository.get_sensitive_by_email(email)
+        if not user or not user.verified or not user.is_active:
+            self._fail(email=email, reason="user_not_allowed", app_code=app_code)
+
+        result = await self._login_service.complete_member_login(user, app_code=app_code)
+        self._audit(outcome="success", email=email, reason="ok", app_code=app_code)
+        return result

--- a/portal/application/auth/results.py
+++ b/portal/application/auth/results.py
@@ -20,6 +20,7 @@ class HeaderInfo(BaseModel):
     host: Optional[str] = Field(None, description="Host")
     referer: Optional[str] = Field(None, description="Referer")
     origin: Optional[str] = Field(None, description="Origin")
+    mock_login_secret: Optional[str] = Field(None, description="X-Mock-Login-Secret")
 
 
 class TokenPayload(BaseModel):

--- a/portal/config.py
+++ b/portal/config.py
@@ -125,6 +125,11 @@ class Configuration(BaseSettings):
     # Example: facility-booking|http://localhost:5174,another-app|http://localhost:5180
     MEMBER_WEB_APPS: str = os.getenv(key="MEMBER_WEB_APPS", default="facility-booking|http://localhost:5174")
 
+    # [Member mock login — dev/staging QA only; never enable in production]
+    MOCK_LOGIN_ENABLED: bool = Converter.to_bool(os.getenv(key="MOCK_LOGIN_ENABLED", default="false"), default=False)
+    MOCK_LOGIN_SECRET: Optional[str] = os.getenv(key="MOCK_LOGIN_SECRET", default=None)
+    TESTING_ACCOUNT_EMAIL_SUFFIX: str = os.getenv(key="TESTING_ACCOUNT_EMAIL_SUFFIX", default="@test.local")
+
     # [Token Blacklist]
     TOKEN_BLACKLIST_REDIS_DB: int = int(os.getenv(key="TOKEN_BLACKLIST_REDIS_DB", default="1"))
     TOKEN_BLACKLIST_CLEANUP_INTERVAL: int = int(os.getenv(key="TOKEN_BLACKLIST_CLEANUP_INTERVAL", default="3600"))

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -40,6 +40,7 @@ class RootContainer(containers.DeclarativeContainer):
     login_service = admin.login_service
     refresh_token_service = admin.refresh_token_service
     microsoft_auth_service = admin.microsoft_auth_service
+    mock_login_auth_service = admin.mock_login_auth_service
     member_web_app_registry = admin.member_web_app_registry
     locale_service = admin.locale_service
     setting_service = admin.setting_service

--- a/portal/containers/admin.py
+++ b/portal/containers/admin.py
@@ -8,6 +8,7 @@ from portal.application.audit.rbac_audit_service import RbacAuditService
 from portal.application.auth.admin_user_service import AdminUserService
 from portal.application.auth.login_service import LoginService
 from portal.application.auth.microsoft_auth_service import MicrosoftAuthService
+from portal.application.auth.mock_login_auth_service import MockLoginAuthService
 from portal.application.auth.refresh_token_service import RefreshTokenService
 from portal.application.auth.user_read_service import UserReadService
 from portal.application.locale.locale_service import LocaleService
@@ -104,6 +105,9 @@ class AdminContainer(containers.DeclarativeContainer):
         microsoft_oidc_provider=core.microsoft_oidc_provider,
         login_service=login_service,
         member_web_app_registry=member_web_app_registry,
+    )
+    mock_login_auth_service = providers.Factory(
+        MockLoginAuthService, user_repository=user_repository, login_service=login_service, member_web_app_registry=member_web_app_registry
     )
 
     verb_repository = providers.Factory(VerbRepository, session=core.request_session)

--- a/portal/middlewares/core_request.py
+++ b/portal/middlewares/core_request.py
@@ -145,6 +145,7 @@ class CoreRequestMiddleware(BaseHTTPMiddleware):
             host=headers.get("host"),
             referer=headers.get("referer"),
             origin=headers.get("origin"),
+            mock_login_secret=headers.get("x-mock-login-secret"),
         )
 
     @inject

--- a/portal/routers/apis/v1/auth.py
+++ b/portal/routers/apis/v1/auth.py
@@ -5,17 +5,31 @@ Member authentication HTTP routes.
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, status
 
-from portal.application.auth.commands import LogoutCommand, MicrosoftLoginCommand, RefreshTokenCommand
+from portal.application.auth.commands import LogoutCommand, MicrosoftLoginCommand, MockLoginCommand, RefreshTokenCommand
 from portal.application.auth.login_service import LoginService
 from portal.application.auth.mappers import member_login_result_to_api, member_profile_result_to_api, token_result_to_api
 from portal.application.auth.microsoft_auth_service import MicrosoftAuthService
+from portal.application.auth.mock_login_auth_service import MockLoginAuthService
 from portal.application.auth.refresh_token_service import RefreshTokenService
 from portal.container import Container
 from portal.routers.auth_router import AuthRouter
-from portal.serializers.apis.v1.auth import MemberInfo, MemberLoginResponse, MicrosoftIdTokenRequest
+from portal.serializers.apis.v1.auth import MemberInfo, MemberLoginResponse, MicrosoftIdTokenRequest, MockLoginRequest
 from portal.serializers.mixins import LogoutRequest, LogoutResponse, RefreshTokenRequest, TokenResponse
 
 router: AuthRouter = AuthRouter()
+
+
+@router.post(
+    "/mock-login",
+    response_model=MemberLoginResponse,
+    response_model_by_alias=True,
+    require_auth=False,
+    responses={401: {"description": "Unauthorized", "content": {"application/json": {"example": {"detail": "Unauthorized"}}}}},
+)
+@inject
+async def member_mock_login(body: MockLoginRequest, mock_login_auth_service: MockLoginAuthService = Depends(Provide[Container.mock_login_auth_service])):
+    result = await mock_login_auth_service.mock_member_login(MockLoginCommand(email=body.email))
+    return member_login_result_to_api(result)
 
 
 @router.post(

--- a/portal/serializers/apis/v1/auth.py
+++ b/portal/serializers/apis/v1/auth.py
@@ -34,3 +34,9 @@ class MicrosoftIdTokenRequest(BaseModel):
     """Microsoft Entra ID token exchange body."""
 
     id_token: str = Field(..., description="Microsoft ID token")
+
+
+class MockLoginRequest(BaseModel):
+    """Mock login body for dev/staging testing accounts."""
+
+    email: str = Field(..., description="Testing account email")

--- a/tests/application/auth/test_mock_login_auth_service.py
+++ b/tests/application/auth/test_mock_login_auth_service.py
@@ -1,0 +1,168 @@
+"""
+Tests for MockLoginAuthService.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from portal.application.auth.commands import MockLoginCommand
+from portal.application.auth.mock_login_auth_service import MOCK_LOGIN_UNAUTHORIZED_DETAIL, MockLoginAuthService
+from portal.application.auth.results import HeaderInfo, MemberLoginResult, MemberProfileResult, TokenResult, UserSensitive
+from portal.domain.auth.member_web_app import MemberWebApp, MemberWebAppRegistry
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.contexts.request_context import RequestContext, reset_request_context, set_request_context
+
+
+class StubLoginService:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    async def complete_member_login(self, user, app_code):
+        self.calls.append((user, app_code))
+        return MemberLoginResult(
+            member=MemberProfileResult(
+                id=user.id,
+                email=user.email or "",
+                first_name=user.first_name or "",
+                last_name=user.last_name or "",
+                preferred_name=user.preferred_name,
+                roles=[],
+                preferred_locale_id=user.preferred_locale_id,
+                last_login_at=user.last_login_at,
+            ),
+            token=TokenResult(access_token="access", refresh_token="refresh", token_type="bearer", expires_in=900),
+        )
+
+
+class StubUserRepository:
+    def __init__(self, user=None):
+        self._user = user
+
+    async def get_sensitive_by_email(self, email):
+        return self._user
+
+
+def _registry() -> MemberWebAppRegistry:
+    return MemberWebAppRegistry([MemberWebApp(code="facility-booking", origins=frozenset({"http://localhost:5174"}))])
+
+
+def _set_origin(origin: str = "http://localhost:5174", mock_login_secret: str | None = None):
+    return set_request_context(RequestContext(headers=HeaderInfo(origin=origin, mock_login_secret=mock_login_secret)))
+
+
+@pytest.fixture
+def mock_login_settings(monkeypatch):
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_ENABLED", True)
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.ENV", "dev")
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_SECRET", None)
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.TESTING_ACCOUNT_EMAIL_SUFFIX", "@test.local")
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_happy_path_delegates(mock_login_settings):
+    user_id = uuid4()
+    user = UserSensitive(id=user_id, email="qa@test.local", verified=True, is_active=True, is_admin=False, first_name="QA")
+    login_service = StubLoginService()
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=login_service, member_web_app_registry=_registry())
+    token = _set_origin()
+    try:
+        result = await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+    assert isinstance(result, MemberLoginResult)
+    assert len(login_service.calls) == 1
+    assert login_service.calls[0][0].id == user_id
+    assert login_service.calls[0][1] == "facility-booking"
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_when_disabled(mock_login_settings, monkeypatch):
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_ENABLED", False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin()
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_in_staging_without_secret_config(mock_login_settings, monkeypatch):
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.ENV", "stg")
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_SECRET", None)
+    user = UserSensitive(id=uuid4(), email="qa@test.local", verified=True, is_active=True, is_admin=False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin()
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_invalid_suffix(mock_login_settings):
+    user = UserSensitive(id=uuid4(), email="qa@example.com", verified=True, is_active=True, is_admin=False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin()
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@example.com"))
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_invalid_secret(mock_login_settings, monkeypatch):
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_SECRET", "expected-secret")
+    user = UserSensitive(id=uuid4(), email="qa@test.local", verified=True, is_active=True, is_admin=False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin(mock_login_secret="wrong-secret")
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_accepts_matching_secret(mock_login_settings, monkeypatch):
+    monkeypatch.setattr("portal.application.auth.mock_login_auth_service.settings.MOCK_LOGIN_SECRET", "expected-secret")
+    user = UserSensitive(id=uuid4(), email="qa@test.local", verified=True, is_active=True, is_admin=False)
+    login_service = StubLoginService()
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=login_service, member_web_app_registry=_registry())
+    token = _set_origin(mock_login_secret="expected-secret")
+    try:
+        result = await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+    assert isinstance(result, MemberLoginResult)
+    assert len(login_service.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_unknown_origin(mock_login_settings):
+    user = UserSensitive(id=uuid4(), email="qa@test.local", verified=True, is_active=True, is_admin=False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin(origin="http://unknown.example")
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.asyncio
+async def test_mock_member_login_rejects_inactive_user(mock_login_settings):
+    user = UserSensitive(id=uuid4(), email="qa@test.local", verified=True, is_active=False, is_admin=False)
+    service = MockLoginAuthService(user_repository=StubUserRepository(user=user), login_service=StubLoginService(), member_web_app_registry=_registry())
+    token = _set_origin()
+    try:
+        with pytest.raises(UnauthorizedException, match=MOCK_LOGIN_UNAUTHORIZED_DETAIL):
+            await service.mock_member_login(MockLoginCommand(email="qa@test.local"))
+    finally:
+        reset_request_context(token)


### PR DESCRIPTION
## Summary

Add `POST /api/v1/auth/mock-login` so Facility Booking QA can obtain real member JWTs in dev/staging without Microsoft Entra ID. Testing accounts are identified by email suffix (`@test.local` by default); success reuses `LoginService.complete_member_login` (same response shape as Microsoft member login). All failure paths return a generic `401 Unauthorized` to avoid account enumeration.

Closes #119

Parent: efcnewlife/facility-booking-frontend#66

ADR: `docs/adr/0014-mock-login-member-auth.md`

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Settings: `MOCK_LOGIN_ENABLED`, `MOCK_LOGIN_SECRET`, `TESTING_ACCOUNT_EMAIL_SUFFIX` (documented in `example.env`).
- Gates: feature flag + non-prod, email suffix, verified/active user, member web app Origin (`MEMBER_WEB_APPS`), secret header when `MOCK_LOGIN_SECRET` is set; staging (`ENV=stg`) fails closed unless secret is configured and matches.
- Application-layer audit via structured `logger.info` on success/failure.
- No Alembic migration in this slice. Testing account CLI tracked separately in #118.

### Manual verification (curl)

Prerequisites: `MOCK_LOGIN_ENABLED=true`, a verified/active `@test.local` user in `auth.user`.

```bash
curl -sS -X POST http://127.0.0.1:8000/api/v1/auth/mock-login \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:5174' \
  -d '{"email":"qa@test.local"}'
```

Staging (requires configured secret):

```bash
curl -sS -X POST https://<staging-api>/api/v1/auth/mock-login \
  -H 'Content-Type: application/json' \
  -H 'Origin: https://<booking-staging-url>' \
  -H 'X-Mock-Login-Secret: <MOCK_LOGIN_SECRET>' \
  -d '{"email":"qa@test.local"}'
```

## Testing

- [x] `uv run pytest tests/application/auth/test_mock_login_auth_service.py -v` (8 passed)
- [x] `uv run ruff format` and `uv run ruff check --fix` (pre-commit hook on commit)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)