### PR TITLE
feat(cli): add create-mock-user for Facility Booking QA accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ uv run pytest tests/application/rbac/test_permission_service.py -v
 # Demo pack (after catalog seeds; optional create-superuser first)
 uv run python -m portal.cli.main seed-local-demo
 
+# Facility Booking mock-login testing account (dev/staging QA; email suffix @test.local)
+uv run python -m portal.cli.main create-mock-user
+
 # Format (layout, then import sort — I only)
 uv run ruff format
 uv run ruff check --fix

--- a/README.md
+++ b/README.md
@@ -483,6 +483,9 @@ uv run python -m portal.cli.main init-rbac
 # 3. First portal admin (interactive prompts)
 uv run python -m portal.cli.main create-superuser
 
+# 3b. Optional: Facility Booking mock-login testing account (dev/staging QA)
+uv run python -m portal.cli.main create-mock-user
+
 # 4. Optional: org position seed data
 uv run python -m portal.cli.main seed-positions
 
@@ -506,6 +509,7 @@ uv run python -m portal.cli.main seed-local-demo
 | `init-locales`          | Insert supported `SystemLocale` rows from `portal/cli/datas/locale_data.py`.                                                  |
 | `init-rbac`             | Seed verbs, resources, permissions, and the `admin` role from `portal/cli/datas/rbac_seed_data.py`. Safe to re-run (upserts). |
 | `create-superuser`      | Create an `AuthUser` with `is_admin` / `is_superuser` via interactive prompts.                                                |
+| `create-mock-user`      | Create a member testing account for Facility Booking mock login (email must end with `TESTING_ACCOUNT_EMAIL_SUFFIX`, default `@test.local`). |
 | `seed-positions`        | Upsert org positions and translations from `portal/cli/datas/position_seed_data.py`.                                          |
 | `seed-ministry-types`   | Upsert ministry type catalog (`outreach`, `internal`, `worship`) and translations.                                            |
 | `seed-target-audiences` | Upsert target audience catalog (`children`, `youths`, `adults`, `family`, `all_ages`) and translations.                       |

--- a/portal/application/cli/mock_user_seed_service.py
+++ b/portal/application/cli/mock_user_seed_service.py
@@ -1,0 +1,97 @@
+"""
+Mock testing-account seed use case for CLI (Facility Booking QA).
+"""
+
+from typing import Any, Optional
+from uuid import uuid4
+
+import click
+
+from portal.config import settings
+from portal.domain.member.constants import AccountKind
+from portal.libs.consts.enums import Gender
+from portal.libs.database import Session
+from portal.libs.shared import validator
+from portal.models import AuthUser, AuthUserProfile
+
+CLI_ACTOR = "create_mock_user_cli"
+DEFAULT_TESTING_ACCOUNT_EMAIL_SUFFIX = "@test.local"
+
+
+def resolve_testing_account_email_suffix() -> str:
+    """Return configured testing suffix or the project default."""
+    configured = settings.TESTING_ACCOUNT_EMAIL_SUFFIX.strip()
+    return configured or DEFAULT_TESTING_ACCOUNT_EMAIL_SUFFIX
+
+
+def email_has_testing_suffix(email: str, suffix: Optional[str] = None) -> bool:
+    """Return True when email ends with the configured testing-account suffix."""
+    configured_suffix = (suffix if suffix is not None else resolve_testing_account_email_suffix()).strip().lower()
+    if not configured_suffix:
+        return False
+    return email.endswith(configured_suffix)
+
+
+class MockUserSeedService:
+    """Create or return an existing mock-login testing account."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    async def run(self, email: str, first_name: str, last_name: str) -> Optional[Any]:
+        """
+        Create a member testing account when one does not already exist for the email.
+        """
+        normalized_email = (email or "").strip().lower()
+
+        if not normalized_email or not validator.is_email(normalized_email):
+            raise ValueError("Invalid email format")
+        if not email_has_testing_suffix(normalized_email):
+            suffix = resolve_testing_account_email_suffix()
+            raise ValueError(f"Email must end with testing suffix {suffix!r}")
+        first_name = (first_name or "").strip()
+        last_name = (last_name or "").strip()
+        if not first_name:
+            raise ValueError("first_name is required")
+        if not last_name:
+            raise ValueError("last_name is required")
+
+        first_name = first_name[:64]
+        last_name = last_name[:64]
+
+        existing_user_id = await self._session.select(AuthUser.id).where(AuthUser.email == normalized_email).fetchval()
+
+        if existing_user_id:
+            click.echo(f"Testing account already exists: {normalized_email}")
+            return await self._session.select(AuthUser).where(AuthUser.id == existing_user_id).fetchrow()
+
+        user_id = uuid4()
+
+        await (
+            self._session.insert(AuthUser)
+            .values(
+                id=user_id,
+                email=normalized_email,
+                verified=True,
+                is_active=True,
+                is_superuser=False,
+                is_admin=False,
+                account_kind=AccountKind.MEMBER.value,
+                created_by=CLI_ACTOR,
+                updated_by=CLI_ACTOR,
+            )
+            .execute()
+        )
+
+        await (
+            self._session.insert(AuthUserProfile)
+            .values(
+                id=uuid4(), user_id=user_id, first_name=first_name, last_name=last_name, gender=Gender.UNKNOWN.value, created_by=CLI_ACTOR, updated_by=CLI_ACTOR
+            )
+            .execute()
+        )
+
+        await self._session.commit()
+
+        click.echo(f"Mock testing account created: {normalized_email}")
+        return await self._session.select(AuthUser).where(AuthUser.id == user_id).fetchrow()

--- a/portal/cli/main.py
+++ b/portal/cli/main.py
@@ -5,6 +5,7 @@ Main Click CLI entry aggregating all subcommands.
 import click
 
 from .init_locale import init_locales_process
+from .mock_user import create_mock_user_process
 from .rbac import init_rbac_process, reset_rbac_process
 from .seed_facility_rental import seed_facility_rental_process
 from .seed_legal_documents import seed_legal_documents_process
@@ -27,6 +28,12 @@ def cli():
 def create_superuser_cmd():
     """Create a superuser via interactive prompts."""
     create_superuser_process()
+
+
+@cli.command(name="create-mock-user")
+def create_mock_user_cmd():
+    """Create a mock-login testing account (@test.local suffix) via interactive prompts."""
+    create_mock_user_process()
 
 
 @cli.command(name="init-rbac")

--- a/portal/cli/mock_user.py
+++ b/portal/cli/mock_user.py
@@ -1,0 +1,71 @@
+"""
+Mock testing-account CLI commands.
+"""
+
+import asyncio
+
+import click
+
+from portal.application.cli.mock_user_seed_service import MockUserSeedService, email_has_testing_suffix, resolve_testing_account_email_suffix
+from portal.container import Container
+from portal.libs.shared import validator
+
+
+async def create_mock_user(email: str, first_name: str, last_name: str):
+    """Create a mock-login testing account via application seed service."""
+    container = Container()
+    session = container.db_session()
+    try:
+        service = MockUserSeedService(session)
+        return await service.run(email=email, first_name=first_name, last_name=last_name)
+    except Exception as exc:
+        click.echo(f"Error creating mock testing account: {exc}")
+        await session.rollback()
+        return None
+    finally:
+        await session.close()
+
+
+def create_mock_user_process() -> None:
+    """Create a mock-login testing account via interactive prompts."""
+    suffix = resolve_testing_account_email_suffix()
+    click.echo(
+        f"\nThis process will guide you through creating a {click.style('mock-login testing account', fg='blue')} "
+        f"(email suffix {click.style(suffix, fg='cyan')})."
+    )
+    click.echo("Please enter the following information.\n")
+
+    while True:
+        email = click.prompt(click.style(f"Enter testing account email (must end with {suffix})", fg="green"), type=str)
+        normalized = email.strip().lower()
+        if not validator.is_email(normalized):
+            click.echo(click.style("Invalid email format. Please enter a valid email address.", fg="red"))
+            continue
+        if not email_has_testing_suffix(normalized):
+            click.echo(click.style(f"Email must end with {suffix!r}. Please try again.", fg="red"))
+            continue
+        email = normalized
+        break
+
+    while True:
+        first_name = click.prompt(click.style("Enter first name", fg="green"), type=str).strip()
+        if not first_name:
+            click.echo(click.style("first_name cannot be empty.", fg="red"))
+            continue
+        first_name = first_name[:64]
+        break
+
+    while True:
+        last_name = click.prompt(click.style("Enter last name", fg="green"), type=str).strip()
+        if not last_name:
+            click.echo(click.style("last_name cannot be empty.", fg="red"))
+            continue
+        last_name = last_name[:64]
+        break
+
+    result = asyncio.run(create_mock_user(email=email, first_name=first_name, last_name=last_name))
+
+    if result is not None:
+        click.echo(click.style(f"\nMock testing account process finished: {email}", fg="bright_green"))
+    else:
+        click.echo(click.style("\nMock testing account process failed.", fg="red"))

--- a/tests/application/cli/test_mock_user_seed_service.py
+++ b/tests/application/cli/test_mock_user_seed_service.py
@@ -1,0 +1,111 @@
+"""
+Tests for mock testing-account seed service.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from portal.application.cli.mock_user_seed_service import MockUserSeedService, email_has_testing_suffix
+from portal.domain.member.constants import AccountKind
+
+
+class StubSession:
+    def __init__(self, *, existing_email: str | None = None):
+        self.existing_email = existing_email
+        self.inserted_auth_users: list[dict] = []
+        self.inserted_profiles: list[dict] = []
+        self.committed = False
+        self._created_user_id = uuid4()
+
+    def select(self, *args, **kwargs):
+        return self
+
+    def where(self, *args, **kwargs):
+        return self
+
+    async def fetchval(self):
+        if self.existing_email:
+            return uuid4()
+        return None
+
+    async def fetchrow(self):
+        return {"id": self._created_user_id}
+
+    def insert(self, model):
+        self._insert_model = model
+        return self
+
+    def values(self, **kwargs):
+        if self._insert_model.__name__ == "AuthUser":
+            self.inserted_auth_users.append(kwargs)
+        else:
+            self.inserted_profiles.append(kwargs)
+        return self
+
+    async def execute(self):
+        return None
+
+    async def commit(self):
+        self.committed = True
+
+
+@pytest.mark.parametrize(
+    ("email", "suffix", "expected"),
+    [
+        ("qa.owner@test.local", "@test.local", True),
+        ("qa.owner@example.com", "@test.local", False),
+        ("user@qa.test", "@qa.test", True),
+        ("user@test.local", "", False),
+    ],
+)
+def test_email_has_testing_suffix(email: str, suffix: str, expected: bool):
+    assert email_has_testing_suffix(email, suffix=suffix) is expected
+
+
+@pytest.mark.asyncio
+async def test_create_mock_user_inserts_member_account():
+    session = StubSession()
+    service = MockUserSeedService(session)
+
+    await service.run(email="qa.owner@test.local", first_name="QA", last_name="Owner")
+
+    assert session.committed is True
+    assert len(session.inserted_auth_users) == 1
+    user_row = session.inserted_auth_users[0]
+    assert user_row["email"] == "qa.owner@test.local"
+    assert user_row["verified"] is True
+    assert user_row["is_active"] is True
+    assert user_row["is_admin"] is False
+    assert user_row["is_superuser"] is False
+    assert user_row["account_kind"] == AccountKind.MEMBER.value
+    assert "password_hash" not in user_row
+
+    assert len(session.inserted_profiles) == 1
+    profile_row = session.inserted_profiles[0]
+    assert profile_row["first_name"] == "QA"
+    assert profile_row["last_name"] == "Owner"
+
+
+@pytest.mark.asyncio
+async def test_create_mock_user_rejects_non_testing_suffix():
+    session = StubSession()
+    service = MockUserSeedService(session)
+
+    with pytest.raises(ValueError, match="testing suffix"):
+        await service.run(email="qa.owner@example.com", first_name="QA", last_name="Owner")
+
+    assert session.committed is False
+    assert session.inserted_auth_users == []
+
+
+@pytest.mark.asyncio
+async def test_create_mock_user_returns_existing_without_insert():
+    session = StubSession(existing_email="existing@test.local")
+    service = MockUserSeedService(session)
+
+    result = await service.run(email="existing@test.local", first_name="Existing", last_name="User")
+
+    assert result is not None
+    assert session.committed is False
+    assert session.inserted_auth_users == []


### PR DESCRIPTION
## Summary

Add `create-mock-user` CLI so operators can provision Facility Booking mock-login testing accounts without Admin UI or self-registration. Emails must end with `TESTING_ACCOUNT_EMAIL_SUFFIX` (default `@test.local`); the command creates a verified, active member `AuthUser` and profile with no password. Re-running for an existing email is idempotent.

Closes #118

Related: #119 (mock-login API), efcnewlife/facility-booking-frontend#66

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Mirrors `create-superuser` / Microsoft directory sync member patterns: `AccountKind.MEMBER`, `verified=True`, `is_active=True`, no `password_hash`.
- Suffix validation uses `resolve_testing_account_email_suffix()` so CLI prompts and service errors share the same default (`@test.local`).
- Seed logic in `portal/application/cli/mock_user_seed_service.py`; thin Click entry in `portal/cli/mock_user.py`.
- Persona/ministry relationship seeding is out of scope (follow-up ticket per #118).

### Manual verification

```bash
uv run python -m portal.cli.main create-mock-user
# Enter e.g. qa.owner@test.local, first/last name
# Then sign in via Facility Booking mock login (MOCK_LOGIN_ENABLED=true)
```

## Testing

- [x] `uv run pytest tests/application/cli/test_mock_user_seed_service.py -v` (7 passed)
- [x] `uv run ruff format` and `uv run ruff check --fix` (pre-commit hook on commit)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge