### PR TITLE
feat(facility): member preview-quote per line intervals (#123)

### DIFF
--- a/docs/adr/0016-member-preview-quote-per-line.md
+++ b/docs/adr/0016-member-preview-quote-per-line.md
@@ -1,0 +1,69 @@
+# 0016. Member preview-quote uses per-line intervals
+
+## Status
+
+Accepted
+
+## Context
+
+`POST /api/v1/facility/preview-quote` accepts one `start_at` / `end_at` and a room list. The mapper applies that single interval's billed hours to every room line (`member_preview_quote_to_command`). That matches the retired "shared interval + up to three rooms" UX, not the Booking cart where each line has its own time.
+
+Admin `POST /admin/api/v1/facility/rental-rate/preview-quote` already accepts `billed_hours` per `room_lines` entry; only the **member** contract needs to change.
+
+`PricingService.preview_quote` and booking create already support per-line `billed_hours`; this ADR is API-boundary only for the member surface.
+
+## Decision
+
+### Request contract
+
+Replace the shared-interval member preview shape with **per-line times**:
+
+- Request body carries **1-3 lines**, each with:
+  - `facility_id` (required)
+  - `start_at` (required)
+  - `end_at` (required)
+- Top-level `start_at` / `end_at` are **removed** from the member preview request (breaking change; no v1 dual-shape).
+- Booking-level fields unchanged: `ministry_id`, `is_mission_aligned`, `currency`, `surcharge_codes`.
+
+Example request shape (snake_case on the wire per member API convention):
+
+```json
+{
+  "ministry_id": "...",
+  "is_mission_aligned": false,
+  "currency": "CAD",
+  "surcharge_codes": [],
+  "lines": [{ "facility_id": "...", "start_at": "...", "end_at": "..." }]
+}
+```
+
+### Validation
+
+- `lines`: `min_length=1`, `max_length=3`.
+- Each line: `end_at > start_at`.
+- Same calendar-day and no cross-midnight rules as ADR 0015 (reuse shared validator where possible).
+- Reject exact duplicate lines (same `facility_id`, `start_at`, `end_at`).
+- Ministry gate and steward rules unchanged (`preview_quote_for_member`).
+
+### Mapping and response
+
+- `BookingService.preview_quote_for_member` validates lines (ADR 0015 rules), then sets `PreviewQuoteRoomLineCommand.billed_hours` from each line's `(start_at, end_at)`.
+- Response shape (`roomLines`, totals) **unchanged**; each `roomLines[i]` reflects that line's interval and subtotal.
+- Order of `room_lines` in the response matches request `lines` order.
+
+### Create booking alignment
+
+- Member `POST /api/v1/facility/bookings` should accept the same per-line interval shape and set header envelope per ADR 0015 so preview totals match create.
+
+## Consequences
+
+- facility-booking-frontend cart can quote after each ADD without forcing a shared interval.
+- Breaking change for any client still sending top-level `start_at` / `end_at` + `rooms[]` only; coordinate with facility-booking-frontend#73.
+- Admin preview-quote API unchanged.
+- Tests that assert `member_preview_quote_to_command` copies one interval to all rooms must be replaced.
+
+## Related
+
+- core-api#123
+- ADR 0015 (line rules and header envelope)
+- facility-booking-frontend#73, #74

--- a/portal/application/facility/booking_service.py
+++ b/portal/application/facility/booking_service.py
@@ -8,12 +8,19 @@ from typing import Optional
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from portal.application.facility.booking_line_validation import envelope_interval, primary_facility_id, resolve_booking_lines, validate_booking_lines
+from portal.application.facility.booking_line_validation import (
+    ResolvedBookingLine,
+    envelope_interval,
+    primary_facility_id,
+    resolve_booking_lines,
+    validate_booking_lines,
+)
 from portal.application.facility.commands import (
     BookingPagesQueryCommand,
     BookingRangeQueryCommand,
     CancelBookingCommand,
     CreateBookingCommand,
+    MemberPreviewQuoteCommand,
     PreviewQuoteCommand,
     PreviewQuoteRoomLineCommand,
     UpdateBookingCommand,
@@ -336,9 +343,30 @@ class BookingService:
         return row
 
     @distributed_trace()
-    async def preview_quote_for_member(self, command: PreviewQuoteCommand) -> PreviewQuoteResult:
+    async def preview_quote_for_member(self, command: MemberPreviewQuoteCommand) -> PreviewQuoteResult:
         await self._validate_ministry_booking_gate(command.ministry_id)
-        return await self._pricing_service.preview_quote(command)
+
+        resolved_lines = [
+            ResolvedBookingLine(facility_id=line.facility_id, start_at=line.start_at, end_at=line.end_at, sequence=index)
+            for index, line in enumerate(command.lines)
+        ]
+        local_tz = await self._setting_service.get_facility_timezone()
+        validate_booking_lines(resolved_lines, local_tz)
+
+        quote_lines = [
+            PreviewQuoteRoomLineCommand(facility_id=line.facility_id, billed_hours=self._billed_hours(line.start_at, line.end_at)) for line in resolved_lines
+        ]
+
+        return await self._pricing_service.preview_quote(
+            PreviewQuoteCommand(
+                booking_type=BookingType.ONE_TIME,
+                is_mission_aligned=command.is_mission_aligned,
+                currency=command.currency,
+                room_lines=quote_lines,
+                surcharge_codes=command.surcharge_codes,
+                ministry_id=command.ministry_id,
+            )
+        )
 
     async def _raise_if_room_unavailable(
         self, facility_id: UUID, start_at: datetime, end_at: datetime, local_tz: ZoneInfo, exclude_booking_id: Optional[UUID] = None

--- a/portal/application/facility/commands.py
+++ b/portal/application/facility/commands.py
@@ -206,6 +206,24 @@ class PreviewQuoteRoomLineCommand(BaseModel):
     billed_hours: Decimal = Field(...)
 
 
+class MemberPreviewQuoteLineCommand(BaseModel):
+    """Member preview quote line with interval."""
+
+    facility_id: UUID = Field(...)
+    start_at: datetime = Field(...)
+    end_at: datetime = Field(...)
+
+
+class MemberPreviewQuoteCommand(BaseModel):
+    """Member preview quote input."""
+
+    is_mission_aligned: bool = Field(default=False)
+    ministry_id: Optional[UUID] = Field(default=None)
+    currency: str = Field(default="CAD")
+    surcharge_codes: list[str] = Field(default_factory=list)
+    lines: list[MemberPreviewQuoteLineCommand] = Field(min_length=1, max_length=3)
+
+
 class PreviewQuoteCommand(BaseModel):
     """Preview rental quote."""
 

--- a/portal/application/facility/mappers.py
+++ b/portal/application/facility/mappers.py
@@ -18,6 +18,8 @@ from portal.application.facility.commands import (
     CreateSurchargeCommand,
     DeleteCommand,
     FacilityTranslationCommand,
+    MemberPreviewQuoteCommand,
+    MemberPreviewQuoteLineCommand,
     PagesQueryCommand,
     PreviewQuoteCommand,
     PreviewQuoteRoomLineCommand,
@@ -114,6 +116,7 @@ from portal.serializers.apis.v1.facility import (
     MemberBookingDetail,
     MemberBookingDetailRoom,
     MemberDayAvailability,
+    MemberPreviewQuoteLineInput,
     MemberPreviewQuoteRequest,
     MemberPreviewQuoteResponse,
     MemberPreviewQuoteRoomLineResult,
@@ -420,20 +423,13 @@ def preview_quote_result_to_api(result: PreviewQuoteResult) -> AdminPreviewQuote
     )
 
 
-def _billed_hours(start_at: datetime, end_at: datetime) -> Decimal:
-    hours = Decimal(str((end_at - start_at).total_seconds())) / Decimal("3600")
-    return hours.quantize(Decimal("0.01"))
-
-
-def member_preview_quote_to_command(model: MemberPreviewQuoteRequest) -> PreviewQuoteCommand:
-    billed_hours = _billed_hours(model.start_at, model.end_at)
-    return PreviewQuoteCommand(
-        booking_type=BookingType.ONE_TIME,
+def member_preview_quote_to_command(model: MemberPreviewQuoteRequest) -> MemberPreviewQuoteCommand:
+    return MemberPreviewQuoteCommand(
         is_mission_aligned=model.is_mission_aligned,
-        currency=model.currency,
-        room_lines=[PreviewQuoteRoomLineCommand(facility_id=line.facility_id, billed_hours=billed_hours) for line in model.rooms],
-        surcharge_codes=model.surcharge_codes,
         ministry_id=model.ministry_id,
+        currency=model.currency,
+        surcharge_codes=model.surcharge_codes,
+        lines=[MemberPreviewQuoteLineCommand(facility_id=line.facility_id, start_at=line.start_at, end_at=line.end_at) for line in model.lines],
     )
 
 

--- a/portal/serializers/apis/v1/facility.py
+++ b/portal/serializers/apis/v1/facility.py
@@ -111,22 +111,22 @@ class MemberBookingDetail(UUIDBaseModel):
     rooms: list[MemberBookingDetailRoom] = Field(default_factory=list)
 
 
-class MemberPreviewQuoteRoomInput(BaseModel):
-    """Room line for member preview quote."""
+class MemberPreviewQuoteLineInput(BaseModel):
+    """Booking line for member preview quote."""
 
     facility_id: UUID = Field(...)
+    start_at: datetime = Field(...)
+    end_at: datetime = Field(...)
 
 
 class MemberPreviewQuoteRequest(BaseModel):
-    """Preview quote for a One-time interval and room list."""
+    """Preview quote for One-time booking lines (each with its own interval)."""
 
-    start_at: datetime = Field(...)
-    end_at: datetime = Field(...)
     is_mission_aligned: bool = Field(default=False)
     ministry_id: Optional[UUID] = Field(default=None)
     currency: str = Field(default="CAD")
     surcharge_codes: list[str] = Field(default_factory=list)
-    rooms: list[MemberPreviewQuoteRoomInput] = Field(min_length=1, max_length=3)
+    lines: list[MemberPreviewQuoteLineInput] = Field(min_length=1, max_length=3)
 
 
 class MemberPreviewQuoteRoomLineResult(BaseModel):

--- a/tests/application/facility/test_booking_service.py
+++ b/tests/application/facility/test_booking_service.py
@@ -13,21 +13,32 @@ from portal.application.facility.commands import (
     BookingRangeQueryCommand,
     BookingRoomLineCommand,
     CancelBookingCommand,
+    MemberPreviewQuoteCommand,
+    MemberPreviewQuoteLineCommand,
     PreviewQuoteCommand,
     PreviewQuoteRoomLineCommand,
 )
+from portal.application.facility.pricing_service import PricingService
 from portal.application.facility.results import BookingDetailResult, BookingRoomLineResult, PreviewQuoteRoomLineResult
 from portal.domain.facility.constants import BookingStatus, BookingType, RentalPolicySettingKey
 from portal.exceptions.responses import BadRequestException, ConflictErrorException, ForbiddenException, NotFoundException
 from tests.fixtures.facility.factories import (
     make_booking_list_item,
     make_create_booking_command,
+    make_hourly_and_daily_rates,
     make_ministry_detail,
     make_preview_quote_result,
     make_update_booking_command,
     new_uuid,
 )
-from tests.fixtures.facility.stubs import StubBookingRepository, StubMinistryRepository, StubPricingService, StubRentalRepository, StubRoomBlackoutRepository
+from tests.fixtures.facility.stubs import (
+    StubBookingRepository,
+    StubMinistryRepository,
+    StubPricingService,
+    StubRentalRepository,
+    StubRoomBlackoutRepository,
+    StubRoomRepository,
+)
 from tests.fixtures.system.stubs import StubSettingService
 
 
@@ -524,16 +535,77 @@ async def test_preview_quote_for_member_honors_ministry_gate(monkeypatch):
         StubBookingRepository(), ministry_stub=StubMinistryRepository(ministry_by_id={ministry_id: ministry}, booking_member_user_ids={user_id})
     )
     room_id = uuid4()
-    command = PreviewQuoteCommand(
-        booking_type=BookingType.ONE_TIME,
-        is_mission_aligned=True,
-        ministry_id=ministry_id,
-        room_lines=[PreviewQuoteRoomLineCommand(facility_id=room_id, billed_hours=Decimal("4"))],
+    start = datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+    command = MemberPreviewQuoteCommand(
+        is_mission_aligned=True, ministry_id=ministry_id, lines=[MemberPreviewQuoteLineCommand(facility_id=room_id, start_at=start, end_at=end)]
     )
     result = await service.preview_quote_for_member(command)
     assert result.quoted_amount == Decimal("150")
     assert service._pricing_service.preview_calls[-1].is_mission_aligned is True
     assert service._pricing_service.preview_calls[-1].ministry_id == ministry_id
+
+
+@pytest.mark.asyncio
+async def test_preview_quote_for_member_passes_per_line_billed_hours(monkeypatch):
+    _user_ctx(monkeypatch)
+    room_id = new_uuid()
+    service = _booking_service(StubBookingRepository())
+    command = MemberPreviewQuoteCommand(
+        lines=[
+            MemberPreviewQuoteLineCommand(
+                facility_id=room_id, start_at=datetime(2026, 8, 22, 9, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 11, 0, tzinfo=timezone.utc)
+            ),
+            MemberPreviewQuoteLineCommand(
+                facility_id=room_id, start_at=datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+            ),
+        ]
+    )
+    await service.preview_quote_for_member(command)
+    preview_command = service._pricing_service.preview_calls[-1]
+    assert preview_command.room_lines[0].billed_hours == Decimal("2.00")
+    assert preview_command.room_lines[1].billed_hours == Decimal("4.00")
+
+
+@pytest.mark.asyncio
+async def test_preview_quote_for_member_same_room_different_subtotals(monkeypatch):
+    _user_ctx(monkeypatch)
+    room_id = new_uuid()
+    rental = StubRentalRepository(rates_by_facility={room_id: make_hourly_and_daily_rates(room_id, hourly_amount=Decimal("10"))})
+    pricing = PricingService(rental, StubRoomRepository(existing_ids={room_id}))
+    service = BookingService(StubBookingRepository(), pricing, rental, StubMinistryRepository(), StubRoomBlackoutRepository(), StubSettingService())
+    command = MemberPreviewQuoteCommand(
+        lines=[
+            MemberPreviewQuoteLineCommand(
+                facility_id=room_id, start_at=datetime(2026, 8, 22, 9, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 11, 0, tzinfo=timezone.utc)
+            ),
+            MemberPreviewQuoteLineCommand(
+                facility_id=room_id, start_at=datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+            ),
+        ]
+    )
+    result = await service.preview_quote_for_member(command)
+    assert result.room_lines[0].line_subtotal == Decimal("20.00")
+    assert result.room_lines[1].line_subtotal == Decimal("40.00")
+    assert result.subtotal_amount == Decimal("60.00")
+
+
+@pytest.mark.asyncio
+async def test_preview_quote_for_member_rejects_duplicate_line(monkeypatch):
+    _user_ctx(monkeypatch)
+    room_id = new_uuid()
+    service = _booking_service(StubBookingRepository())
+    start = datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+    command = MemberPreviewQuoteCommand(
+        lines=[
+            MemberPreviewQuoteLineCommand(facility_id=room_id, start_at=start, end_at=end),
+            MemberPreviewQuoteLineCommand(facility_id=room_id, start_at=start, end_at=end),
+        ]
+    )
+    with pytest.raises(BadRequestException) as exc_info:
+        await service.preview_quote_for_member(command)
+    assert exc_info.value.error_code == "FACILITY_BOOKING_DUPLICATE_LINE"
 
 
 @pytest.mark.asyncio
@@ -544,8 +616,8 @@ async def test_preview_quote_for_member_rejects_non_steward(monkeypatch):
     service = _booking_service(
         StubBookingRepository(), ministry_stub=StubMinistryRepository(ministry_by_id={ministry_id: ministry}, booking_member_user_ids=set())
     )
-    command = PreviewQuoteCommand(
-        booking_type=BookingType.ONE_TIME, ministry_id=ministry_id, room_lines=[PreviewQuoteRoomLineCommand(facility_id=uuid4(), billed_hours=Decimal("4"))]
-    )
+    start = datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+    command = MemberPreviewQuoteCommand(ministry_id=ministry_id, lines=[MemberPreviewQuoteLineCommand(facility_id=uuid4(), start_at=start, end_at=end)])
     with pytest.raises(ForbiddenException):
         await service.preview_quote_for_member(command)

--- a/tests/application/facility/test_mappers.py
+++ b/tests/application/facility/test_mappers.py
@@ -60,7 +60,7 @@ from portal.serializers.admin.v1.facility.room_slot_template import AdminRoomSlo
 from portal.serializers.admin.v1.facility.translation import AdminFacilityTranslationInput
 from portal.serializers.admin.v1.ministry import AdminMinistryCreate, AdminMinistryMemberInput, AdminMinistryReplaceMembers
 from portal.serializers.admin.v1.org.translation import AdminOrgTranslationInput
-from portal.serializers.apis.v1.facility import MemberPreviewQuoteRequest, MemberPreviewQuoteRoomInput
+from portal.serializers.apis.v1.facility import MemberPreviewQuoteLineInput, MemberPreviewQuoteRequest
 from portal.serializers.mixins import DeleteBaseModel, GenericQueryBaseModel
 
 
@@ -319,22 +319,29 @@ def test_override_log_pages_query_to_command():
     assert command.facility_id == facility_id
 
 
-def test_member_preview_quote_to_command_uses_one_time_interval_hours():
+def test_member_preview_quote_to_command_maps_per_line_intervals():
     facility_id = uuid4()
+    line_one_start = datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc)
+    line_one_end = datetime(2026, 8, 22, 16, 0, tzinfo=timezone.utc)
+    line_two_start = datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc)
+    line_two_end = datetime(2026, 8, 22, 22, 0, tzinfo=timezone.utc)
     model = MemberPreviewQuoteRequest(
-        start_at=datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc),
-        end_at=datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc),
         is_mission_aligned=True,
         surcharge_codes=["audio_system"],
-        rooms=[MemberPreviewQuoteRoomInput(facility_id=facility_id)],
+        lines=[
+            MemberPreviewQuoteLineInput(facility_id=facility_id, start_at=line_one_start, end_at=line_one_end),
+            MemberPreviewQuoteLineInput(facility_id=facility_id, start_at=line_two_start, end_at=line_two_end),
+        ],
     )
     command = member_preview_quote_to_command(model)
-    assert command.booking_type == BookingType.ONE_TIME
     assert command.is_mission_aligned is True
     assert command.ministry_id is None
     assert command.surcharge_codes == ["audio_system"]
-    assert command.room_lines[0].facility_id == facility_id
-    assert command.room_lines[0].billed_hours == Decimal("4.00")
+    assert command.lines[0].facility_id == facility_id
+    assert command.lines[0].start_at == line_one_start
+    assert command.lines[0].end_at == line_one_end
+    assert command.lines[1].start_at == line_two_start
+    assert command.lines[1].end_at == line_two_end
 
 
 def test_member_preview_quote_result_to_api_includes_money_fields():
@@ -377,24 +384,34 @@ def test_room_availability_item_to_api_includes_photo_urls():
     assert dumped["photoUrls"] == ["https://cdn.example/a.jpg"]
 
 
-def test_member_preview_quote_maps_three_rooms_from_one_interval():
+def test_member_preview_quote_maps_three_lines_with_distinct_intervals():
     rooms = [uuid4(), uuid4(), uuid4()]
     model = MemberPreviewQuoteRequest(
-        start_at=datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc),
-        end_at=datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc),
-        rooms=[MemberPreviewQuoteRoomInput(facility_id=room_id) for room_id in rooms],
+        lines=[
+            MemberPreviewQuoteLineInput(
+                facility_id=room_id, start_at=datetime(2026, 8, 22, 9, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 11, 0, tzinfo=timezone.utc)
+            )
+            for room_id in rooms
+        ]
     )
     command = member_preview_quote_to_command(model)
-    assert [line.facility_id for line in command.room_lines] == rooms
-    assert all(line.billed_hours == Decimal("4.00") for line in command.room_lines)
+    assert [line.facility_id for line in command.lines] == rooms
+    assert all(line.end_at > line.start_at for line in command.lines)
 
 
-def test_member_preview_quote_rejects_empty_and_more_than_three_rooms():
+def test_member_preview_quote_rejects_empty_and_more_than_three_lines():
     interval = dict(start_at=datetime(2026, 8, 22, 14, 0, tzinfo=timezone.utc), end_at=datetime(2026, 8, 22, 18, 0, tzinfo=timezone.utc))
     with pytest.raises(ValidationError):
-        MemberPreviewQuoteRequest(**interval, rooms=[])
+        MemberPreviewQuoteRequest(lines=[])
     with pytest.raises(ValidationError):
-        MemberPreviewQuoteRequest(**interval, rooms=[MemberPreviewQuoteRoomInput(facility_id=uuid4()) for _ in range(4)])
+        MemberPreviewQuoteRequest(
+            lines=[
+                MemberPreviewQuoteLineInput(facility_id=uuid4(), **interval),
+                MemberPreviewQuoteLineInput(facility_id=uuid4(), **interval),
+                MemberPreviewQuoteLineInput(facility_id=uuid4(), **interval),
+                MemberPreviewQuoteLineInput(facility_id=uuid4(), **interval),
+            ]
+        )
 
 
 def test_member_booking_detail_to_api_includes_quoted_amount():

--- a/tests/application/facility/test_pricing_service.py
+++ b/tests/application/facility/test_pricing_service.py
@@ -74,6 +74,24 @@ async def test_preview_quote_daily_flat_subtotal_for_six_hours():
 
 
 @pytest.mark.asyncio
+async def test_preview_quote_same_room_different_durations_different_subtotals():
+    room_id = new_uuid()
+    rental = StubRentalRepository(rates_by_facility={room_id: make_hourly_and_daily_rates(room_id, hourly_amount=Decimal("10"))})
+    service = _pricing_service(rental, {room_id})
+    command = PreviewQuoteCommand(
+        booking_type=BookingType.ONE_TIME,
+        room_lines=[
+            PreviewQuoteRoomLineCommand(facility_id=room_id, billed_hours=Decimal("2")),
+            PreviewQuoteRoomLineCommand(facility_id=room_id, billed_hours=Decimal("4")),
+        ],
+    )
+    result = await service.preview_quote(command)
+    assert result.room_lines[0].line_subtotal == Decimal("20.00")
+    assert result.room_lines[1].line_subtotal == Decimal("40.00")
+    assert result.subtotal_amount == Decimal("60.00")
+
+
+@pytest.mark.asyncio
 async def test_preview_quote_sums_multiple_room_lines():
     room_a = new_uuid()
     room_b = new_uuid()


### PR DESCRIPTION
## Summary

Member `POST /api/v1/facility/preview-quote` now accepts per-line `start_at` / `end_at` on `lines[]` (1–3 rows) instead of a single shared interval applied to every room. Each quoted `roomLines[i].lineSubtotal` reflects that line's duration so the Timetable Booking cart can show a price after each Confirm Booking Time.

Breaking change: top-level `start_at` / `end_at` and `rooms[]` are removed from the member preview request. See ADR 0016.

Closes #123

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [x] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Reuses ADR 0015 `validate_booking_lines` (same calendar day, no cross-midnight, no exact duplicate lines).
- `BookingService.preview_quote_for_member` validates lines then computes per-line `billed_hours` before calling `PricingService`.
- Response shape (`roomLines`, totals) is unchanged.
- Admin preview-quote API is unchanged.
- Coordinate with facility-booking-frontend#73 for the new request shape.

## Testing

- [x] `uv run pytest tests/application/facility/test_mappers.py tests/application/facility/test_booking_service.py tests/application/facility/test_pricing_service.py -v`
- [x] `uv run ruff format` and `uv run ruff check --fix` on changed files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)